### PR TITLE
Update Ticket IDs for cassettes. Re-record needed cassettes.

### DIFF
--- a/cassettes/test_create_ticket.yaml
+++ b/cassettes/test_create_ticket.yaml
@@ -19,7 +19,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAMh0d2UC/0ut9MpIck/O9M/08gyt8jT0y/Qs9swLMk129jTzzC6ICHP2stRLrfTKSfVwzPTP
+        H4sIACCUumUC/0ut9MpIck/O9M/08gyt8jT0y/Qs9swLMk129jTzzC6ICHP2stRLrfTKSfVwzPTP
         8jT0dUmv8A/xLPd1cbLUy48KSdI1T8mpKvRISQ5394kI8851LDXLNfQqDTGqjE8vNffUDYn0czML
         yQYA/EJXWGkAAAA=
     headers:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 11 Dec 2023 20:44:52 GMT
+      - Wed, 31 Jan 2024 18:40:25 GMT
       Expires:
       - '-1'
       Pragma:
@@ -48,11 +48,11 @@ interactions:
       X-RateLimit-Remaining:
       - '59'
       X-RateLimit-Reset:
-      - Mon, 11 Dec 2023 20:45:51 GMT
+      - Wed, 31 Jan 2024 18:41:25 GMT
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - '3345419373167109285'
+      - '6754950246019097024'
       X-UA-Compatible:
       - IE=edge
     status:
@@ -91,11 +91,11 @@ interactions:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '4167946'
+      - '4182985'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 11 Dec 2023 20:44:53 GMT
+      - Wed, 31 Jan 2024 18:40:28 GMT
       Expires:
       - '-1'
       Pragma:
@@ -109,7 +109,7 @@ interactions:
       X-RateLimit-Remaining:
       - '59'
       X-RateLimit-Reset:
-      - Mon, 11 Dec 2023 20:45:53 GMT
+      - Wed, 31 Jan 2024 18:41:27 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -117,7 +117,7 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - '6758738251409011500'
+      - '8566862768188044166'
       X-TDX-UID:
       - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
@@ -155,7 +155,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 11 Dec 2023 20:44:54 GMT
+      - Wed, 31 Jan 2024 18:40:30 GMT
       Expires:
       - '-1'
       Pragma:
@@ -169,7 +169,7 @@ interactions:
       X-RateLimit-Remaining:
       - '59'
       X-RateLimit-Reset:
-      - Mon, 11 Dec 2023 20:45:55 GMT
+      - Wed, 31 Jan 2024 18:41:31 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -177,7 +177,7 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - '5988445569559771640'
+      - '8800828208247051824'
       X-TDX-UID:
       - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
@@ -204,7 +204,7 @@ interactions:
     uri: https://help.uillinois.edu/SBTDWebApi/api/people/lookup?searchText=thor2&maxResults=1
   response:
     body:
-      string: '[{"UID": "54b3b2ee-90c9-ea11-a81d-000d3a8ea9f7", "ReferenceID": 48436,
+      string: '[{"UID": "b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7", "ReferenceID": 48141,
         "BEID": "0f7df9ca-3924-4806-8adc-6e880a796ddc", "BEIDInt": 2, "IsActive":
         true, "IsConfidential": false, "UserName": "", "FullName": "Jane Foster",
         "FirstName": "Jane", "LastName": "Foster", "MiddleName": null, "Salutation":
@@ -231,11 +231,11 @@ interactions:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '1563'
+      - '1567'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 11 Dec 2023 20:44:54 GMT
+      - Wed, 31 Jan 2024 18:40:31 GMT
       Expires:
       - '-1'
       Pragma:
@@ -249,7 +249,7 @@ interactions:
       X-RateLimit-Remaining:
       - '74'
       X-RateLimit-Reset:
-      - Mon, 11 Dec 2023 20:45:05 GMT
+      - Wed, 31 Jan 2024 18:40:41 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -257,7 +257,7 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - '8423273371909577072'
+      - '8750846893212312369'
       X-TDX-UID:
       - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
@@ -315,7 +315,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 11 Dec 2023 20:44:54 GMT
+      - Wed, 31 Jan 2024 18:40:31 GMT
       Expires:
       - '-1'
       Pragma:
@@ -329,7 +329,7 @@ interactions:
       X-RateLimit-Remaining:
       - '59'
       X-RateLimit-Reset:
-      - Mon, 11 Dec 2023 20:45:55 GMT
+      - Wed, 31 Jan 2024 18:41:31 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -337,7 +337,7 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - '3691534179145196312'
+      - '5694325632894723557'
       X-TDX-UID:
       - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
@@ -376,16 +376,19 @@ interactions:
         Carpenter","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":1310,"Name":"Out
         of Office Request","AppID":66,"AppName":"UIUC - Tech Services Privacy and
         Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":true,"ShouldExpandHelp":true,"CreatedDate":"2023-06-15T16:07:41.54Z","CreatedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"CLEANED
-        CLEANED","ModifiedDate":"2023-07-14T21:00:05.697Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
+        CLEANED","ModifiedDate":"2023-10-18T19:21:10.533Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
         CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":639,"Name":"Problem
         Form","AppID":66,"AppName":"UIUC - Tech Services Privacy and Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":true,"ShouldExpandHelp":false,"CreatedDate":"2021-07-13T18:48:46.04Z","CreatedUid":"a2ff1781-8ec9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"Nathan
         Carpenter","ModifiedDate":"2022-12-19T19:48:33.27Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
         CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":641,"Name":"Release
         Form","AppID":66,"AppName":"UIUC - Tech Services Privacy and Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":true,"ShouldExpandHelp":false,"CreatedDate":"2021-07-13T18:48:46.05Z","CreatedUid":"a2ff1781-8ec9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"Nathan
         Carpenter","ModifiedDate":"2021-07-13T18:48:46.183Z","ModifiedUid":"a2ff1781-8ec9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"Nathan
-        Carpenter","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":1274,"Name":"Test
+        Carpenter","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":1471,"Name":"Request
+        For Access","AppID":66,"AppName":"UIUC - Tech Services Privacy and Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":true,"ShouldExpandHelp":true,"CreatedDate":"2023-09-13T19:36:07.307Z","CreatedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"CLEANED
+        CLEANED","ModifiedDate":"2023-11-08T20:17:16.06Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
+        CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":1274,"Name":"Test
         Approval Form","AppID":66,"AppName":"UIUC - Tech Services Privacy and Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":true,"ShouldExpandHelp":false,"CreatedDate":"2023-05-24T15:47:41.72Z","CreatedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"CLEANED
-        CLEANED","ModifiedDate":"2023-05-24T15:49:49.353Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
+        CLEANED","ModifiedDate":"2023-10-23T19:30:04.12Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
         CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":693,"Name":"UIUC-TechServices-Privacy
         New Request","AppID":66,"AppName":"UIUC - Tech Services Privacy and Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":true,"ShouldExpandHelp":true,"CreatedDate":"2021-10-06T18:16:01.103Z","CreatedUid":"a2ff1781-8ec9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"Nathan
         Carpenter","ModifiedDate":"2022-12-14T20:40:09.41Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
@@ -394,7 +397,7 @@ interactions:
         Shanahan","ModifiedDate":"2023-05-31T19:30:42.903Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
         CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":1069,"Name":"UIUC-TechSvc-CSOC
         Incidents","AppID":66,"AppName":"UIUC - Tech Services Privacy and Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":false,"ShouldExpandHelp":false,"CreatedDate":"2022-06-29T19:56:54.657Z","CreatedUid":"4d0d8b10-8fc9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"Robert
-        Shanahan","ModifiedDate":"2023-05-31T19:40:06.407Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
+        Shanahan","ModifiedDate":"2023-11-09T20:28:50.84Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
         CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":1070,"Name":"UIUC-TechSvc-CSOC
         Informational","AppID":66,"AppName":"UIUC - Tech Services Privacy and Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":false,"ShouldExpandHelp":false,"CreatedDate":"2022-06-29T20:06:49.573Z","CreatedUid":"4d0d8b10-8fc9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"Robert
         Shanahan","ModifiedDate":"2023-05-31T19:30:50.84Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
@@ -418,21 +421,21 @@ interactions:
         CLEANED","ModifiedDate":"2023-02-15T21:37:21.473Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
         CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":1174,"Name":"UIUC-TechSvc-Vulnerability","AppID":66,"AppName":"UIUC
         - Tech Services Privacy and Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":true,"ShouldExpandHelp":false,"CreatedDate":"2022-12-14T20:46:18.923Z","CreatedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"CLEANED
-        CLEANED","ModifiedDate":"2023-02-15T21:13:31.43Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
+        CLEANED","ModifiedDate":"2023-12-04T21:01:43.413Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
         CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1},{"ID":1421,"Name":"Urgent
         Access Termination","AppID":66,"AppName":"UIUC - Tech Services Privacy and
         Cybersecurity","ComponentID":9,"IsActive":true,"IsConfigured":true,"IsDefaultForApp":false,"IsPinned":true,"ShouldExpandHelp":true,"CreatedDate":"2023-08-02T19:38:13.33Z","CreatedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","CreatedFullName":"CLEANED
-        CLEANED","ModifiedDate":"2023-08-09T19:40:26.36Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
+        CLEANED","ModifiedDate":"2023-09-06T19:52:21.283Z","ModifiedUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ModifiedFullName":"CLEANED
         CLEANED","AssetsCount":-1,"ConfigurationItemsCount":-1}]'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '10164'
+      - '10688'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 11 Dec 2023 20:44:55 GMT
+      - Wed, 31 Jan 2024 18:40:31 GMT
       Expires:
       - '-1'
       Pragma:
@@ -446,7 +449,7 @@ interactions:
       X-RateLimit-Remaining:
       - '59'
       X-RateLimit-Reset:
-      - Mon, 11 Dec 2023 20:45:55 GMT
+      - Wed, 31 Jan 2024 18:41:31 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -454,7 +457,7 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - '7167059365412705991'
+      - '4434036526904221740'
       X-TDX-UID:
       - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
@@ -463,7 +466,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"AccountID": 7902, "PriorityID": 19, "RequestorUid": "54b3b2ee-90c9-ea11-a81d-000d3a8ea9f7",
+    body: '{"AccountID": 7902, "PriorityID": 19, "RequestorUid": "b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7",
       "Title": "NewBoo", "TypeID": 312, "Attributes": [{"ID": "4363", "Value": "8172"},
       {"ID": "4902", "Value": "10539"}], "FormID": 1069}'
     headers:
@@ -497,13 +500,13 @@ interactions:
         "IsSlaRespondByViolated": false, "IsSlaResolveByViolated": false, "RespondByDate":
         "0001-01-01T00:00:00", "ResolveByDate": "0001-01-01T00:00:00", "SlaBeginDate":
         "0001-01-01T00:00:00", "IsOnHold": false, "PlacedOnHoldDate": "0001-01-01T00:00:00",
-        "GoesOffHoldDate": "0001-01-01T00:00:00", "CreatedDate": "2023-12-11T20:44:56.267Z",
+        "GoesOffHoldDate": "0001-01-01T00:00:00", "CreatedDate": "2024-01-31T18:40:32.353Z",
         "CreatedUid": "a68e93bc-e406-ee11-87dd-0050f2e6c034", "CreatedFullName": "Security
-        SOAR API Service Account", "CreatedEmail": "", "ModifiedDate": "2023-12-11T20:44:56.267Z",
+        SOAR API Service Account", "CreatedEmail": "", "ModifiedDate": "2024-01-31T18:40:32.353Z",
         "ModifiedUid": "a68e93bc-e406-ee11-87dd-0050f2e6c034", "ModifiedFullName":
         "Security SOAR API Service Account", "RequestorName": "Jane Foster", "RequestorFirstName":
         "Jane", "RequestorLastName": "Foster", "RequestorEmail": "nobody@example.com",
-        "RequestorPhone": null, "RequestorUid": "54b3b2ee-90c9-ea11-a81d-000d3a8ea9f7",
+        "RequestorPhone": null, "RequestorUid": "b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7",
         "ActualMinutes": 0, "EstimatedMinutes": 0, "DaysOld": 0, "StartDate": null,
         "EndDate": null, "ResponsibleUid": null, "ResponsibleFullName": "Unassigned",
         "ResponsibleEmail": "", "ResponsibleGroupID": 0, "ResponsibleGroupName": "",
@@ -535,19 +538,23 @@ interactions:
         "2023-03-13T19:34:05.217Z", "DateModified": "2023-04-17T20:49:18.803Z", "Order":
         4}, {"ID": 10542, "Name": "Critical - Major", "IsActive": true, "DateCreated":
         "2023-04-17T20:49:12.407Z", "DateModified": "2023-04-17T20:49:12.407Z", "Order":
-        5}], "IsRequired": false, "IsUpdatable": true, "Value": "10539", "ValueText":
+        5}, {"ID": 15624, "Name": "Mutli-Campus", "IsActive": true, "DateCreated":
+        "2023-12-05T19:40:38.35Z", "DateModified": "2023-12-05T19:40:38.35Z", "Order":
+        6}], "IsRequired": false, "IsUpdatable": true, "Value": "10539", "ValueText":
         "To Be Determined", "ChoicesText": "To Be Determined", "AssociatedItemIDs":
         [0]}, {"ID": 4363, "Name": "UIUC-TechSvc-Security TLP", "Order": 0, "Description":
         "Traffic Light Protocol sharing classification - See also https://wiki.illinois.edu/wiki/display/SEC/Traffic+Light+Protocol+-TLP",
         "SectionID": 0, "SectionName": null, "FieldType": "dropdown", "DataType":
-        "String", "Choices": [{"ID": 8175, "Name": "TLP:WHITE", "IsActive": true,
-        "DateCreated": "2022-06-29T20:23:50.033Z", "DateModified": "2022-06-29T20:23:50.033Z",
+        "String", "Choices": [{"ID": 8175, "Name": "TLP:CLEAR", "IsActive": true,
+        "DateCreated": "2022-06-29T20:23:50.033Z", "DateModified": "2023-09-14T17:33:23.823Z",
         "Order": 0}, {"ID": 8174, "Name": "TLP:GREEN", "IsActive": true, "DateCreated":
         "2022-06-29T20:23:49.927Z", "DateModified": "2022-06-29T20:23:49.927Z", "Order":
         1}, {"ID": 8173, "Name": "TLP:AMBER", "IsActive": true, "DateCreated": "2022-06-29T20:23:49.827Z",
-        "DateModified": "2022-06-29T20:23:49.827Z", "Order": 2}, {"ID": 8172, "Name":
+        "DateModified": "2022-06-29T20:23:49.827Z", "Order": 2}, {"ID": 14037, "Name":
+        "TLP:AMBER+STRICT", "IsActive": true, "DateCreated": "2023-09-14T17:33:09.307Z",
+        "DateModified": "2023-09-14T17:33:09.307Z", "Order": 3}, {"ID": 8172, "Name":
         "TLP:RED", "IsActive": true, "DateCreated": "2022-06-29T20:23:49.723Z", "DateModified":
-        "2022-06-29T20:23:49.723Z", "Order": 3}], "IsRequired": false, "IsUpdatable":
+        "2023-09-14T17:33:16.707Z", "Order": 4}], "IsRequired": false, "IsUpdatable":
         true, "Value": "8172", "ValueText": "TLP:RED", "ChoicesText": "TLP:RED", "AssociatedItemIDs":
         [0]}], "Attachments": [], "Tasks": [], "Notify": [{"ItemRole": "Requestor",
         "Name": "Jane Foster", "Initials": null, "Value": "nobody@example.com", "RefValue":
@@ -557,11 +564,11 @@ interactions:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '5101'
+      - '5394'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 11 Dec 2023 20:44:55 GMT
+      - Wed, 31 Jan 2024 18:40:31 GMT
       Expires:
       - '-1'
       Pragma:
@@ -575,7 +582,7 @@ interactions:
       X-RateLimit-Remaining:
       - '119'
       X-RateLimit-Reset:
-      - Mon, 11 Dec 2023 20:45:56 GMT
+      - Wed, 31 Jan 2024 18:41:32 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -583,7 +590,7 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - '2149316269131206143'
+      - '3849815518956002798'
       X-TDX-UID:
       - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:

--- a/cassettes/test_reassign_group.yaml
+++ b/cassettes/test_reassign_group.yaml
@@ -19,7 +19,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAPNri2QC/0ut9MpIck/O9M/08gyt8jT0y/Qs9swLMk129jTzzC6ICHP2stRLrfTKSfVwzPTP
+        H4sIALKWumUC/0ut9MpIck/O9M/08gyt8jT0y/Qs9swLMk129jTzzC6ICHP2stRLrfTKSfVwzPTP
         8jT0dUmv8A/xLPd1cbLUy48KSdI1T8mpKvRISQ5394kI8851LDXLNfQqDTGqjE8vNffUDYn0czML
         yQYA/EJXWGkAAAA=
     headers:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 15 Jun 2023 19:52:16 GMT
+      - Wed, 31 Jan 2024 18:51:28 GMT
       Expires:
       - '-1'
       Pragma:
@@ -46,13 +46,13 @@ interactions:
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '51'
+      - '59'
       X-RateLimit-Reset:
-      - Thu, 15 Jun 2023 19:52:54 GMT
+      - Wed, 31 Jan 2024 18:52:28 GMT
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - 8f9cac7c-2140-4ca0-9eed-26b8671315b9
+      - '1784425194128173017'
       X-UA-Compatible:
       - IE=edge
     status:
@@ -89,11 +89,11 @@ interactions:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '166364'
+      - '219024'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 15 Jun 2023 19:52:18 GMT
+      - Wed, 31 Jan 2024 18:51:29 GMT
       Expires:
       - '-1'
       Pragma:
@@ -107,7 +107,7 @@ interactions:
       X-RateLimit-Remaining:
       - '59'
       X-RateLimit-Reset:
-      - Thu, 15 Jun 2023 19:53:18 GMT
+      - Wed, 31 Jan 2024 18:52:29 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -115,9 +115,9 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - 4967bb3c-5985-4537-814f-d0d6feb4c50a
+      - '6932469061899714166'
       X-TDX-UID:
-      - 0bfec2fa-e406-ee11-87dd-0050f2e6c034
+      - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
       - IE=edge
     status:
@@ -139,57 +139,34 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://help.uillinois.edu/SBTDWebApi/api/66/tickets/564073
+    uri: https://help.uillinois.edu/SBTDWebApi/api/66/tickets/1011312
   response:
     body:
-      string: '{"ID":564073,"ParentID":0,"ParentTitle":"","ParentClass":0,"TypeID":312,"TypeName":"Security
+      string: '{"ID":1011312,"ParentID":0,"ParentTitle":"","ParentClass":0,"TypeID":312,"TypeName":"Security
         Support","TypeCategoryID":89,"TypeCategoryName":"UIUC-Privacy and Cybersecurity","Classification":46,"ClassificationName":"Service
-        Request","FormID":693,"FormName":"UIUC-TechServices-Privacy New Request","Title":"NewBoo","Description":"Test
-        request","IsRichHtml":false,"Uri":"api/66/tickets/564073","AccountID":7902,"AccountName":"None/Not
-        Found","SourceID":0,"SourceName":"","StatusID":360,"StatusName":"Resolved","StatusClass":3,"ImpactID":0,"ImpactName":"","UrgencyID":0,"UrgencyName":"","PriorityID":19,"PriorityName":"Low","PriorityOrder":1.0,"SlaID":0,"SlaName":"","IsSlaViolated":false,"IsSlaRespondByViolated":false,"IsSlaResolveByViolated":false,"RespondByDate":"0001-01-01T00:00:00","ResolveByDate":"0001-01-01T00:00:00","SlaBeginDate":"0001-01-01T00:00:00","IsOnHold":false,"PlacedOnHoldDate":"0001-01-01T00:00:00","GoesOffHoldDate":"0001-01-01T00:00:00","CreatedDate":"2022-12-01T17:12:16.05Z","CreatedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","CreatedFullName":"Tech
-        Services Security API","CreatedEmail":"","ModifiedDate":"2023-06-15T19:52:14.713Z","ModifiedUid":"0bfec2fa-e406-ee11-87dd-0050f2e6c034","ModifiedFullName":"Security
-        SOAR API Service Account","RequestorName":"CLEANED CLEANED","RequestorFirstName":"CLEANED","RequestorLastName":"CLEANED","RequestorEmail":"CLEANED@illinois.edu","RequestorPhone":"217-300-5753","RequestorUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ActualMinutes":0,"EstimatedMinutes":0,"DaysOld":14,"StartDate":null,"EndDate":null,"ResponsibleUid":"bbd30493-8ec9-ea11-a81d-000d3a8ea9f7","ResponsibleFullName":"CLEANED
-        CLEANED","ResponsibleEmail":"CLEANED@illinois.edu","ResponsibleGroupID":787,"ResponsibleGroupName":"UIUC-TechServices-Cybersecurity
-        Developers","RespondedDate":"2022-12-01T17:12:16.05Z","RespondedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","RespondedFullName":"Tech
-        Services Security API","CompletedDate":"2022-12-15T16:42:00.94Z","CompletedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","CompletedFullName":"Tech
-        Services Security API","ReviewerUid":null,"ReviewerFullName":"","ReviewerEmail":"","ReviewingGroupID":0,"ReviewingGroupName":"","TimeBudget":0.0,"ExpensesBudget":0.0,"TimeBudgetUsed":0.0,"ExpensesBudgetUsed":0.0,"IsConvertedToTask":false,"ConvertedToTaskDate":"0001-01-01T00:00:00","ConvertedToTaskUid":null,"ConvertedToTaskFullName":"","TaskProjectID":0,"TaskProjectName":"","TaskPlanID":0,"TaskPlanName":"","TaskID":0,"TaskTitle":"","TaskStartDate":"0001-01-01T00:00:00","TaskEndDate":"0001-01-01T00:00:00","TaskPercentComplete":0,"LocationID":0,"LocationName":"","LocationRoomID":0,"LocationRoomName":"","RefCode":"","ServiceID":0,"ServiceName":"None","ServiceOfferingID":0,"ServiceOfferingName":"None","ServiceCategoryID":0,"ServiceCategoryName":"None","ArticleID":0,"ArticleSubject":"","ArticleStatus":0,"ArticleCategoryPathNames":"","ArticleAppID":0,"ArticleShortcutID":null,"AppID":66,"Attributes":[{"ID":3618,"Name":"UIUC-TechSvc-Privacy
-        Nature of Request","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":5279,"Name":"Customer
-        Service Request/ General Inquiry","IsActive":true,"DateCreated":"2021-10-06T18:23:10.183Z","DateModified":"2021-10-06T18:23:10.183Z","Order":1},{"ID":5280,"Name":"Request
-        a new privacy service, project or capability","IsActive":true,"DateCreated":"2021-10-06T18:23:10.19Z","DateModified":"2021-10-06T18:23:10.19Z","Order":2},{"ID":5281,"Name":"Privacy
-        Consultation","IsActive":true,"DateCreated":"2021-10-06T18:23:10.193Z","DateModified":"2021-10-06T18:23:10.193Z","Order":3},{"ID":5282,"Name":"New
-        purchase / third party product or service review","IsActive":true,"DateCreated":"2021-10-06T18:23:10.2Z","DateModified":"2021-10-06T18:23:10.2Z","Order":4},{"ID":5283,"Name":"Compliance-related
-        question","IsActive":true,"DateCreated":"2021-10-06T18:23:10.207Z","DateModified":"2021-10-06T18:23:10.207Z","Order":5},{"ID":5284,"Name":"Request
-        a privacy impact assessment","IsActive":true,"DateCreated":"2021-10-06T18:23:10.213Z","DateModified":"2021-10-06T18:23:10.213Z","Order":6},{"ID":5285,"Name":"Report
-        a possible data incident","IsActive":true,"DateCreated":"2021-10-06T18:23:10.22Z","DateModified":"2021-10-06T18:23:10.22Z","Order":7},{"ID":5286,"Name":"Other","IsActive":true,"DateCreated":"2021-10-06T18:23:10.227Z","DateModified":"2021-10-06T18:23:10.227Z","Order":8}],"IsRequired":false,"IsUpdatable":false,"Value":"5279","ValueText":"Customer
-        Service Request/ General Inquiry","ChoicesText":"Customer Service Request/
-        General Inquiry","AssociatedItemIDs":[0]},{"ID":3621,"Name":"UIUC-TechSvc-Privacy
-        Data Domains","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"checklist","DataType":"String","Choices":[{"ID":5290,"Name":"General
-        Identification Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.11Z","DateModified":"2021-10-06T18:34:43.11Z","Order":1},{"ID":5291,"Name":"Student
-        and Academic Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.117Z","DateModified":"2021-10-06T18:34:43.117Z","Order":2},{"ID":5292,"Name":"Health
-        and Medical Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.123Z","DateModified":"2021-10-06T18:34:43.123Z","Order":3},{"ID":5293,"Name":"Financial
-        and Consumer Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.13Z","DateModified":"2021-10-06T18:34:43.13Z","Order":4},{"ID":5294,"Name":"Employee
-        and Employment Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.137Z","DateModified":"2021-10-06T18:34:43.137Z","Order":5},{"ID":5295,"Name":"Legal
-        and Technical Data (Non-Personal Data)","IsActive":true,"DateCreated":"2021-10-06T18:34:43.14Z","DateModified":"2021-10-06T18:34:43.14Z","Order":6}],"IsRequired":false,"IsUpdatable":false,"Value":"5290","ValueText":"General
-        Identification Data","ChoicesText":"General Identification Data","AssociatedItemIDs":[0]},{"ID":3620,"Name":"UIUC-TechSvc-Privacy
-        Identifiable Data","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5287,"Name":"Yes","IsActive":true,"DateCreated":"2021-10-06T18:31:36.607Z","DateModified":"2021-10-06T18:31:36.607Z","Order":0},{"ID":5288,"Name":"No","IsActive":true,"DateCreated":"2021-10-06T18:31:36.613Z","DateModified":"2021-10-06T18:31:36.613Z","Order":1},{"ID":5289,"Name":"I
-        don''t know","IsActive":true,"DateCreated":"2021-10-06T18:31:36.637Z","DateModified":"2021-10-06T18:31:36.637Z","Order":2}],"IsRequired":false,"IsUpdatable":false,"Value":"5288","ValueText":"No","ChoicesText":"No","AssociatedItemIDs":[0]},{"ID":3623,"Name":"UIUC-TechSvc-Privacy
-        Area","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5300,"Name":"Research","IsActive":true,"DateCreated":"2021-10-06T18:38:19.52Z","DateModified":"2021-10-06T18:38:19.52Z","Order":1},{"ID":5301,"Name":"Administrative
-        / Operational","IsActive":true,"DateCreated":"2021-10-06T18:38:19.527Z","DateModified":"2021-10-06T18:38:19.527Z","Order":2},{"ID":5302,"Name":"Health
-        / Student / Employee Wellness","IsActive":true,"DateCreated":"2021-10-06T18:38:19.537Z","DateModified":"2021-10-06T18:38:19.537Z","Order":3},{"ID":5303,"Name":"Student
-        / Academic","IsActive":true,"DateCreated":"2021-10-06T18:38:19.543Z","DateModified":"2021-10-06T18:38:19.543Z","Order":4},{"ID":5304,"Name":"Other","IsActive":true,"DateCreated":"2021-10-06T18:38:19.55Z","DateModified":"2021-10-06T18:38:19.55Z","Order":5}],"IsRequired":false,"IsUpdatable":false,"Value":"5300","ValueText":"Research","ChoicesText":"Research","AssociatedItemIDs":[0]},{"ID":3625,"Name":"UIUC-TechSvc-Privacy
-        Affiliation","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5305,"Name":"Yes","IsActive":true,"DateCreated":"2021-10-06T18:42:23.347Z","DateModified":"2021-10-06T18:42:23.347Z","Order":0},{"ID":5306,"Name":"No","IsActive":true,"DateCreated":"2021-10-06T18:42:23.357Z","DateModified":"2021-10-06T18:42:23.357Z","Order":1}],"IsRequired":false,"IsUpdatable":false,"Value":"5305","ValueText":"Yes","ChoicesText":"Yes","AssociatedItemIDs":[0]}],"Attachments":[],"Tasks":[],"Notify":[{"ItemRole":"Responsible","Name":"CLEANED
-        CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Responsible
-        Group","Name":"UIUC-TechServices-Cybersecurity Developers","Initials":null,"Value":"787","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Requestor","Name":"CLEANED
+        Request","FormID":1069,"FormName":"UIUC-TechSvc-CSOC Incidents","Title":"NewBoo","Description":"","IsRichHtml":false,"Uri":"api/66/tickets/1011312","AccountID":7902,"AccountName":"None/Not
+        Found","SourceID":0,"SourceName":"","StatusID":357,"StatusName":"New","StatusClass":1,"ImpactID":0,"ImpactName":"","UrgencyID":0,"UrgencyName":"","PriorityID":19,"PriorityName":"Low","PriorityOrder":1.0,"SlaID":0,"SlaName":"","IsSlaViolated":false,"IsSlaRespondByViolated":false,"IsSlaResolveByViolated":false,"RespondByDate":"0001-01-01T00:00:00","ResolveByDate":"0001-01-01T00:00:00","SlaBeginDate":"0001-01-01T00:00:00","IsOnHold":false,"PlacedOnHoldDate":"0001-01-01T00:00:00","GoesOffHoldDate":"0001-01-01T00:00:00","CreatedDate":"2024-01-31T18:40:32.353Z","CreatedUid":"a68e93bc-e406-ee11-87dd-0050f2e6c034","CreatedFullName":"Security
+        SOAR API Service Account","CreatedEmail":"","ModifiedDate":"2024-01-31T18:40:32.353Z","ModifiedUid":"a68e93bc-e406-ee11-87dd-0050f2e6c034","ModifiedFullName":"Security
+        SOAR API Service Account","RequestorName":"CLEANED CLEANED","RequestorFirstName":"CLEANED","RequestorLastName":"CLEANED","RequestorEmail":"CLEANED@illinois.edu","RequestorPhone":"","RequestorUid":"b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7","ActualMinutes":0,"EstimatedMinutes":0,"DaysOld":0,"StartDate":null,"EndDate":null,"ResponsibleUid":null,"ResponsibleFullName":"Unassigned","ResponsibleEmail":"","ResponsibleGroupID":0,"ResponsibleGroupName":"","RespondedDate":"0001-01-01T00:00:00","RespondedUid":null,"RespondedFullName":"","CompletedDate":"0001-01-01T00:00:00","CompletedUid":null,"CompletedFullName":"","ReviewerUid":null,"ReviewerFullName":"","ReviewerEmail":"","ReviewingGroupID":0,"ReviewingGroupName":"","TimeBudget":0.0,"ExpensesBudget":0.0,"TimeBudgetUsed":0.0,"ExpensesBudgetUsed":0.0,"IsConvertedToTask":false,"ConvertedToTaskDate":"0001-01-01T00:00:00","ConvertedToTaskUid":null,"ConvertedToTaskFullName":"","TaskProjectID":0,"TaskProjectName":"","TaskPlanID":0,"TaskPlanName":"","TaskID":0,"TaskTitle":"","TaskStartDate":"0001-01-01T00:00:00","TaskEndDate":"0001-01-01T00:00:00","TaskPercentComplete":0,"LocationID":0,"LocationName":"","LocationRoomID":0,"LocationRoomName":"","RefCode":"","ServiceID":0,"ServiceName":"None","ServiceOfferingID":0,"ServiceOfferingName":"None","ServiceCategoryID":0,"ServiceCategoryName":"None","ArticleID":0,"ArticleSubject":"","ArticleStatus":0,"ArticleCategoryPathNames":"","ArticleAppID":0,"ArticleShortcutID":null,"AppID":66,"Attributes":[{"ID":4902,"Name":"UIUC-TechSvc-CSOC
+        Incident Severity","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":10539,"Name":"To
+        Be Determined","IsActive":true,"DateCreated":"2023-04-17T20:47:47.447Z","DateModified":"2023-04-17T20:47:47.447Z","Order":0},{"ID":10541,"Name":"Non-Event","IsActive":true,"DateCreated":"2023-04-17T20:48:18.213Z","DateModified":"2023-04-17T20:48:33.57Z","Order":1},{"ID":10540,"Name":"Low
+        - Minor","IsActive":true,"DateCreated":"2023-04-17T20:48:05.88Z","DateModified":"2023-04-17T20:48:24.127Z","Order":2},{"ID":10203,"Name":"Medium
+        - Moderate","IsActive":true,"DateCreated":"2023-03-13T19:34:05.207Z","DateModified":"2023-04-17T20:49:23.907Z","Order":3},{"ID":10204,"Name":"High
+        - Serious","IsActive":true,"DateCreated":"2023-03-13T19:34:05.217Z","DateModified":"2023-04-17T20:49:18.803Z","Order":4},{"ID":10542,"Name":"Critical
+        - Major","IsActive":true,"DateCreated":"2023-04-17T20:49:12.407Z","DateModified":"2023-04-17T20:49:12.407Z","Order":5},{"ID":15624,"Name":"Mutli-Campus","IsActive":true,"DateCreated":"2023-12-05T19:40:38.35Z","DateModified":"2023-12-05T19:40:38.35Z","Order":6}],"IsRequired":false,"IsUpdatable":true,"Value":"10539","ValueText":"To
+        Be Determined","ChoicesText":"To Be Determined","AssociatedItemIDs":[0]},{"ID":4363,"Name":"UIUC-TechSvc-Security
+        TLP","Order":0,"Description":"Traffic Light Protocol sharing classification
+        - See also https://wiki.illinois.edu/wiki/display/SEC/Traffic+Light+Protocol+-TLP","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":8175,"Name":"TLP:CLEAR","IsActive":true,"DateCreated":"2022-06-29T20:23:50.033Z","DateModified":"2023-09-14T17:33:23.823Z","Order":0},{"ID":8174,"Name":"TLP:GREEN","IsActive":true,"DateCreated":"2022-06-29T20:23:49.927Z","DateModified":"2022-06-29T20:23:49.927Z","Order":1},{"ID":8173,"Name":"TLP:AMBER","IsActive":true,"DateCreated":"2022-06-29T20:23:49.827Z","DateModified":"2022-06-29T20:23:49.827Z","Order":2},{"ID":14037,"Name":"TLP:AMBER+STRICT","IsActive":true,"DateCreated":"2023-09-14T17:33:09.307Z","DateModified":"2023-09-14T17:33:09.307Z","Order":3},{"ID":8172,"Name":"TLP:RED","IsActive":true,"DateCreated":"2022-06-29T20:23:49.723Z","DateModified":"2023-09-14T17:33:16.707Z","Order":4}],"IsRequired":false,"IsUpdatable":true,"Value":"8172","ValueText":"TLP:RED","ChoicesText":"TLP:RED","AssociatedItemIDs":[0]}],"Attachments":[],"Tasks":[],"Notify":[{"ItemRole":"Requestor","Name":"CLEANED
         CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null}],"WorkflowID":0,"WorkflowConfigurationID":0,"WorkflowName":""}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '8736'
+      - '5394'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 15 Jun 2023 19:52:18 GMT
+      - Wed, 31 Jan 2024 18:51:29 GMT
       Expires:
       - '-1'
       Pragma:
@@ -203,7 +180,7 @@ interactions:
       X-RateLimit-Remaining:
       - '59'
       X-RateLimit-Reset:
-      - Thu, 15 Jun 2023 19:53:19 GMT
+      - Wed, 31 Jan 2024 18:52:30 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -211,110 +188,64 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - 7c226be2-c39f-44e6-8da3-b49712ad7538
+      - '970053645763566185'
       X-TDX-UID:
-      - 0bfec2fa-e406-ee11-87dd-0050f2e6c034
+      - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
       - IE=edge
     status:
       code: 200
       message: OK
 - request:
-    body: '{"ID": 564073, "TypeID": 312, "TypeName": "Security Support", "TypeCategoryID":
+    body: '{"ID": 1011312, "TypeID": 312, "TypeName": "Security Support", "TypeCategoryID":
       89, "TypeCategoryName": "UIUC-Privacy and Cybersecurity", "Classification":
-      46, "ClassificationName": "Service Request", "FormID": 693, "FormName": "UIUC-TechServices-Privacy
-      New Request", "Title": "NewBoo", "Description": "Test request", "Uri": "api/66/tickets/564073",
-      "AccountID": 7902, "AccountName": "None/Not Found", "StatusID": 360, "StatusName":
-      "Resolved", "StatusClass": 3, "PriorityID": 19, "PriorityName": "Low", "PriorityOrder":
-      1.0, "CreatedDate": "2022-12-01T17:12:16+0000", "CreatedUid": "3c3caa7d-c365-ed11-ade6-0050f2e6378b",
-      "CreatedFullName": "Tech Services Security API", "ModifiedDate": "2023-06-15T19:52:14+0000",
-      "ModifiedUid": "0bfec2fa-e406-ee11-87dd-0050f2e6c034", "ModifiedFullName": "Security
+      46, "ClassificationName": "Service Request", "FormID": 1069, "FormName": "UIUC-TechSvc-CSOC
+      Incidents", "Title": "NewBoo", "Uri": "api/66/tickets/1011312", "AccountID":
+      7902, "AccountName": "None/Not Found", "StatusID": 357, "StatusName": "New",
+      "StatusClass": 1, "PriorityID": 19, "PriorityName": "Low", "PriorityOrder":
+      1.0, "CreatedDate": "2024-01-31T18:40:32+0000", "CreatedUid": "a68e93bc-e406-ee11-87dd-0050f2e6c034",
+      "CreatedFullName": "Security SOAR API Service Account", "ModifiedDate": "2024-01-31T18:40:32+0000",
+      "ModifiedUid": "a68e93bc-e406-ee11-87dd-0050f2e6c034", "ModifiedFullName": "Security
       SOAR API Service Account", "RequestorName": "CLEANED CLEANED", "RequestorFirstName":
       "CLEANED", "RequestorLastName": "CLEANED", "RequestorEmail": "CLEANED@illinois.edu",
-      "RequestorPhone": "217-300-5753", "RequestorUid": "a3e79204-8fc9-ea11-a81d-000d3a8ea9f7",
-      "DaysOld": 14, "ResponsibleUid": "bbd30493-8ec9-ea11-a81d-000d3a8ea9f7", "ResponsibleFullName":
-      "CLEANED CLEANED", "ResponsibleEmail": "CLEANED@illinois.edu", "ResponsibleGroupID":
-      787, "ResponsibleGroupName": "UIUC-TechServices-Cybersecurity Developers", "RespondedDate":
-      "2022-12-01T17:12:16+0000", "RespondedUid": "3c3caa7d-c365-ed11-ade6-0050f2e6378b",
-      "RespondedFullName": "Tech Services Security API", "CompletedDate": "2022-12-15T16:42:00+0000",
-      "CompletedUid": "3c3caa7d-c365-ed11-ade6-0050f2e6378b", "CompletedFullName":
-      "Tech Services Security API", "ServiceName": "None", "ServiceOfferingName":
-      "None", "ServiceCategoryName": "None", "AppID": 66, "Attributes": [{"ID": 3618,
-      "Name": "UIUC-TechSvc-Privacy Nature of Request", "Order": 0, "Description":
-      "", "SectionID": 0, "SectionName": null, "FieldType": "dropdown", "DataType":
-      "String", "Choices": [{"ID": 5279, "Name": "Customer Service Request/ General
-      Inquiry", "IsActive": true, "DateCreated": "2021-10-06T18:23:10.183Z", "DateModified":
-      "2021-10-06T18:23:10.183Z", "Order": 1}, {"ID": 5280, "Name": "Request a new
-      privacy service, project or capability", "IsActive": true, "DateCreated": "2021-10-06T18:23:10.19Z",
-      "DateModified": "2021-10-06T18:23:10.19Z", "Order": 2}, {"ID": 5281, "Name":
-      "Privacy Consultation", "IsActive": true, "DateCreated": "2021-10-06T18:23:10.193Z",
-      "DateModified": "2021-10-06T18:23:10.193Z", "Order": 3}, {"ID": 5282, "Name":
-      "New purchase / third party product or service review", "IsActive": true, "DateCreated":
-      "2021-10-06T18:23:10.2Z", "DateModified": "2021-10-06T18:23:10.2Z", "Order":
-      4}, {"ID": 5283, "Name": "Compliance-related question", "IsActive": true, "DateCreated":
-      "2021-10-06T18:23:10.207Z", "DateModified": "2021-10-06T18:23:10.207Z", "Order":
-      5}, {"ID": 5284, "Name": "Request a privacy impact assessment", "IsActive":
-      true, "DateCreated": "2021-10-06T18:23:10.213Z", "DateModified": "2021-10-06T18:23:10.213Z",
-      "Order": 6}, {"ID": 5285, "Name": "Report a possible data incident", "IsActive":
-      true, "DateCreated": "2021-10-06T18:23:10.22Z", "DateModified": "2021-10-06T18:23:10.22Z",
-      "Order": 7}, {"ID": 5286, "Name": "Other", "IsActive": true, "DateCreated":
-      "2021-10-06T18:23:10.227Z", "DateModified": "2021-10-06T18:23:10.227Z", "Order":
-      8}], "IsRequired": false, "IsUpdatable": false, "Value": "5279", "ValueText":
-      "Customer Service Request/ General Inquiry", "ChoicesText": "Customer Service
-      Request/ General Inquiry", "AssociatedItemIDs": [0]}, {"ID": 3621, "Name": "UIUC-TechSvc-Privacy
-      Data Domains", "Order": 0, "Description": "", "SectionID": 0, "SectionName":
-      null, "FieldType": "checklist", "DataType": "String", "Choices": [{"ID": 5290,
-      "Name": "General Identification Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.11Z",
-      "DateModified": "2021-10-06T18:34:43.11Z", "Order": 1}, {"ID": 5291, "Name":
-      "Student and Academic Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.117Z",
-      "DateModified": "2021-10-06T18:34:43.117Z", "Order": 2}, {"ID": 5292, "Name":
-      "Health and Medical Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.123Z",
-      "DateModified": "2021-10-06T18:34:43.123Z", "Order": 3}, {"ID": 5293, "Name":
-      "Financial and Consumer Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.13Z",
-      "DateModified": "2021-10-06T18:34:43.13Z", "Order": 4}, {"ID": 5294, "Name":
-      "Employee and Employment Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.137Z",
-      "DateModified": "2021-10-06T18:34:43.137Z", "Order": 5}, {"ID": 5295, "Name":
-      "Legal and Technical Data (Non-Personal Data)", "IsActive": true, "DateCreated":
-      "2021-10-06T18:34:43.14Z", "DateModified": "2021-10-06T18:34:43.14Z", "Order":
-      6}], "IsRequired": false, "IsUpdatable": false, "Value": "5290", "ValueText":
-      "General Identification Data", "ChoicesText": "General Identification Data",
-      "AssociatedItemIDs": [0]}, {"ID": 3620, "Name": "UIUC-TechSvc-Privacy Identifiable
-      Data", "Order": 0, "Description": "", "SectionID": 0, "SectionName": null, "FieldType":
-      "vradio", "DataType": "String", "Choices": [{"ID": 5287, "Name": "Yes", "IsActive":
-      true, "DateCreated": "2021-10-06T18:31:36.607Z", "DateModified": "2021-10-06T18:31:36.607Z",
-      "Order": 0}, {"ID": 5288, "Name": "No", "IsActive": true, "DateCreated": "2021-10-06T18:31:36.613Z",
-      "DateModified": "2021-10-06T18:31:36.613Z", "Order": 1}, {"ID": 5289, "Name":
-      "I don''t know", "IsActive": true, "DateCreated": "2021-10-06T18:31:36.637Z",
-      "DateModified": "2021-10-06T18:31:36.637Z", "Order": 2}], "IsRequired": false,
-      "IsUpdatable": false, "Value": "5288", "ValueText": "No", "ChoicesText": "No",
-      "AssociatedItemIDs": [0]}, {"ID": 3623, "Name": "UIUC-TechSvc-Privacy Area",
-      "Order": 0, "Description": "", "SectionID": 0, "SectionName": null, "FieldType":
-      "vradio", "DataType": "String", "Choices": [{"ID": 5300, "Name": "Research",
-      "IsActive": true, "DateCreated": "2021-10-06T18:38:19.52Z", "DateModified":
-      "2021-10-06T18:38:19.52Z", "Order": 1}, {"ID": 5301, "Name": "Administrative
-      / Operational", "IsActive": true, "DateCreated": "2021-10-06T18:38:19.527Z",
-      "DateModified": "2021-10-06T18:38:19.527Z", "Order": 2}, {"ID": 5302, "Name":
-      "Health / Student / Employee Wellness", "IsActive": true, "DateCreated": "2021-10-06T18:38:19.537Z",
-      "DateModified": "2021-10-06T18:38:19.537Z", "Order": 3}, {"ID": 5303, "Name":
-      "Student / Academic", "IsActive": true, "DateCreated": "2021-10-06T18:38:19.543Z",
-      "DateModified": "2021-10-06T18:38:19.543Z", "Order": 4}, {"ID": 5304, "Name":
-      "Other", "IsActive": true, "DateCreated": "2021-10-06T18:38:19.55Z", "DateModified":
-      "2021-10-06T18:38:19.55Z", "Order": 5}], "IsRequired": false, "IsUpdatable":
-      false, "Value": "5300", "ValueText": "Research", "ChoicesText": "Research",
-      "AssociatedItemIDs": [0]}, {"ID": 3625, "Name": "UIUC-TechSvc-Privacy Affiliation",
-      "Order": 0, "Description": "", "SectionID": 0, "SectionName": null, "FieldType":
-      "vradio", "DataType": "String", "Choices": [{"ID": 5305, "Name": "Yes", "IsActive":
-      true, "DateCreated": "2021-10-06T18:42:23.347Z", "DateModified": "2021-10-06T18:42:23.347Z",
-      "Order": 0}, {"ID": 5306, "Name": "No", "IsActive": true, "DateCreated": "2021-10-06T18:42:23.357Z",
-      "DateModified": "2021-10-06T18:42:23.357Z", "Order": 1}], "IsRequired": false,
-      "IsUpdatable": false, "Value": "5305", "ValueText": "Yes", "ChoicesText": "Yes",
-      "AssociatedItemIDs": [0]}], "Attachments": [], "Tasks": [], "Notify": [{"ItemRole":
-      "Responsible", "Name": "CLEANED CLEANED", "Initials": null, "Value": "CLEANED@illinois.edu",
-      "RefValue": 0, "ProfileImageFileName": null}, {"ItemRole": "Responsible Group",
-      "Name": "UIUC-TechServices-Cybersecurity Developers", "Initials": null, "Value":
-      "787", "RefValue": 0, "ProfileImageFileName": null}, {"ItemRole": "Requestor",
-      "Name": "CLEANED CLEANED", "Initials": null, "Value": "CLEANED@illinois.edu",
-      "RefValue": 0, "ProfileImageFileName": null}]}'
+      "RequestorUid": "b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7", "ResponsibleFullName":
+      "Unassigned", "ResponsibleGroupID": 787, "ServiceName": "None", "ServiceOfferingName":
+      "None", "ServiceCategoryName": "None", "AppID": 66, "Attributes": [{"ID": 4902,
+      "Name": "UIUC-TechSvc-CSOC Incident Severity", "Order": 0, "Description": "",
+      "SectionID": 0, "SectionName": null, "FieldType": "dropdown", "DataType": "String",
+      "Choices": [{"ID": 10539, "Name": "To Be Determined", "IsActive": true, "DateCreated":
+      "2023-04-17T20:47:47.447Z", "DateModified": "2023-04-17T20:47:47.447Z", "Order":
+      0}, {"ID": 10541, "Name": "Non-Event", "IsActive": true, "DateCreated": "2023-04-17T20:48:18.213Z",
+      "DateModified": "2023-04-17T20:48:33.57Z", "Order": 1}, {"ID": 10540, "Name":
+      "Low - Minor", "IsActive": true, "DateCreated": "2023-04-17T20:48:05.88Z", "DateModified":
+      "2023-04-17T20:48:24.127Z", "Order": 2}, {"ID": 10203, "Name": "Medium - Moderate",
+      "IsActive": true, "DateCreated": "2023-03-13T19:34:05.207Z", "DateModified":
+      "2023-04-17T20:49:23.907Z", "Order": 3}, {"ID": 10204, "Name": "High - Serious",
+      "IsActive": true, "DateCreated": "2023-03-13T19:34:05.217Z", "DateModified":
+      "2023-04-17T20:49:18.803Z", "Order": 4}, {"ID": 10542, "Name": "Critical - Major",
+      "IsActive": true, "DateCreated": "2023-04-17T20:49:12.407Z", "DateModified":
+      "2023-04-17T20:49:12.407Z", "Order": 5}, {"ID": 15624, "Name": "Mutli-Campus",
+      "IsActive": true, "DateCreated": "2023-12-05T19:40:38.35Z", "DateModified":
+      "2023-12-05T19:40:38.35Z", "Order": 6}], "IsRequired": false, "IsUpdatable":
+      true, "Value": "10539", "ValueText": "To Be Determined", "ChoicesText": "To
+      Be Determined", "AssociatedItemIDs": [0]}, {"ID": 4363, "Name": "UIUC-TechSvc-Security
+      TLP", "Order": 0, "Description": "Traffic Light Protocol sharing classification
+      - See also https://wiki.illinois.edu/wiki/display/SEC/Traffic+Light+Protocol+-TLP",
+      "SectionID": 0, "SectionName": null, "FieldType": "dropdown", "DataType": "String",
+      "Choices": [{"ID": 8175, "Name": "TLP:CLEAR", "IsActive": true, "DateCreated":
+      "2022-06-29T20:23:50.033Z", "DateModified": "2023-09-14T17:33:23.823Z", "Order":
+      0}, {"ID": 8174, "Name": "TLP:GREEN", "IsActive": true, "DateCreated": "2022-06-29T20:23:49.927Z",
+      "DateModified": "2022-06-29T20:23:49.927Z", "Order": 1}, {"ID": 8173, "Name":
+      "TLP:AMBER", "IsActive": true, "DateCreated": "2022-06-29T20:23:49.827Z", "DateModified":
+      "2022-06-29T20:23:49.827Z", "Order": 2}, {"ID": 14037, "Name": "TLP:AMBER+STRICT",
+      "IsActive": true, "DateCreated": "2023-09-14T17:33:09.307Z", "DateModified":
+      "2023-09-14T17:33:09.307Z", "Order": 3}, {"ID": 8172, "Name": "TLP:RED", "IsActive":
+      true, "DateCreated": "2022-06-29T20:23:49.723Z", "DateModified": "2023-09-14T17:33:16.707Z",
+      "Order": 4}], "IsRequired": false, "IsUpdatable": true, "Value": "8172", "ValueText":
+      "TLP:RED", "ChoicesText": "TLP:RED", "AssociatedItemIDs": [0]}], "Attachments":
+      [], "Tasks": [], "Notify": [{"ItemRole": "Requestor", "Name": "CLEANED CLEANED",
+      "Initials": null, "Value": "CLEANED@illinois.edu", "RefValue": 0, "ProfileImageFileName":
+      null}]}'
     headers:
       Accept:
       - '*/*'
@@ -325,63 +256,42 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7908'
+      - '4005'
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://help.uillinois.edu/SBTDWebApi/api/66/tickets/564073?notifyNewResponsible=False
+    uri: https://help.uillinois.edu/SBTDWebApi/api/66/tickets/1011312?notifyNewResponsible=False
   response:
     body:
-      string: '{"ID":564073,"ParentID":0,"ParentTitle":"","ParentClass":0,"TypeID":312,"TypeName":"Security
+      string: '{"ID":1011312,"ParentID":0,"ParentTitle":"","ParentClass":0,"TypeID":312,"TypeName":"Security
         Support","TypeCategoryID":89,"TypeCategoryName":"UIUC-Privacy and Cybersecurity","Classification":46,"ClassificationName":"Service
-        Request","FormID":693,"FormName":"UIUC-TechServices-Privacy New Request","Title":"NewBoo","Description":"Test
-        request","IsRichHtml":false,"Uri":"api/66/tickets/564073","AccountID":7902,"AccountName":"None/Not
-        Found","SourceID":0,"SourceName":"","StatusID":360,"StatusName":"Resolved","StatusClass":3,"ImpactID":0,"ImpactName":"","UrgencyID":0,"UrgencyName":"","PriorityID":19,"PriorityName":"Low","PriorityOrder":1.0,"SlaID":0,"SlaName":"","IsSlaViolated":false,"IsSlaRespondByViolated":false,"IsSlaResolveByViolated":false,"RespondByDate":"0001-01-01T00:00:00","ResolveByDate":"0001-01-01T00:00:00","SlaBeginDate":"0001-01-01T00:00:00","IsOnHold":false,"PlacedOnHoldDate":"0001-01-01T00:00:00","GoesOffHoldDate":"0001-01-01T00:00:00","CreatedDate":"2022-12-01T17:12:16.05Z","CreatedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","CreatedFullName":"Tech
-        Services Security API","CreatedEmail":"","ModifiedDate":"2023-06-15T19:52:14.713Z","ModifiedUid":"0bfec2fa-e406-ee11-87dd-0050f2e6c034","ModifiedFullName":"Security
-        SOAR API Service Account","RequestorName":"CLEANED CLEANED","RequestorFirstName":"CLEANED","RequestorLastName":"CLEANED","RequestorEmail":"CLEANED@illinois.edu","RequestorPhone":"217-300-5753","RequestorUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ActualMinutes":0,"EstimatedMinutes":0,"DaysOld":14,"StartDate":null,"EndDate":null,"ResponsibleUid":"bbd30493-8ec9-ea11-a81d-000d3a8ea9f7","ResponsibleFullName":"CLEANED
-        CLEANED","ResponsibleEmail":"CLEANED@illinois.edu","ResponsibleGroupID":787,"ResponsibleGroupName":"UIUC-TechServices-Cybersecurity
-        Developers","RespondedDate":"2022-12-01T17:12:16.05Z","RespondedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","RespondedFullName":"Tech
-        Services Security API","CompletedDate":"2022-12-15T16:42:00.94Z","CompletedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","CompletedFullName":"Tech
-        Services Security API","ReviewerUid":null,"ReviewerFullName":"","ReviewerEmail":"","ReviewingGroupID":0,"ReviewingGroupName":"","TimeBudget":0.0,"ExpensesBudget":0.0,"TimeBudgetUsed":0.0,"ExpensesBudgetUsed":0.0,"IsConvertedToTask":false,"ConvertedToTaskDate":"0001-01-01T00:00:00","ConvertedToTaskUid":null,"ConvertedToTaskFullName":"","TaskProjectID":0,"TaskProjectName":"","TaskPlanID":0,"TaskPlanName":"","TaskID":0,"TaskTitle":"","TaskStartDate":"0001-01-01T00:00:00","TaskEndDate":"0001-01-01T00:00:00","TaskPercentComplete":0,"LocationID":0,"LocationName":"","LocationRoomID":0,"LocationRoomName":"","RefCode":"","ServiceID":0,"ServiceName":"None","ServiceOfferingID":0,"ServiceOfferingName":"None","ServiceCategoryID":0,"ServiceCategoryName":"None","ArticleID":0,"ArticleSubject":"","ArticleStatus":0,"ArticleCategoryPathNames":"","ArticleAppID":0,"ArticleShortcutID":null,"AppID":66,"Attributes":[{"ID":3618,"Name":"UIUC-TechSvc-Privacy
-        Nature of Request","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":5279,"Name":"Customer
-        Service Request/ General Inquiry","IsActive":true,"DateCreated":"2021-10-06T18:23:10.183Z","DateModified":"2021-10-06T18:23:10.183Z","Order":1},{"ID":5280,"Name":"Request
-        a new privacy service, project or capability","IsActive":true,"DateCreated":"2021-10-06T18:23:10.19Z","DateModified":"2021-10-06T18:23:10.19Z","Order":2},{"ID":5281,"Name":"Privacy
-        Consultation","IsActive":true,"DateCreated":"2021-10-06T18:23:10.193Z","DateModified":"2021-10-06T18:23:10.193Z","Order":3},{"ID":5282,"Name":"New
-        purchase / third party product or service review","IsActive":true,"DateCreated":"2021-10-06T18:23:10.2Z","DateModified":"2021-10-06T18:23:10.2Z","Order":4},{"ID":5283,"Name":"Compliance-related
-        question","IsActive":true,"DateCreated":"2021-10-06T18:23:10.207Z","DateModified":"2021-10-06T18:23:10.207Z","Order":5},{"ID":5284,"Name":"Request
-        a privacy impact assessment","IsActive":true,"DateCreated":"2021-10-06T18:23:10.213Z","DateModified":"2021-10-06T18:23:10.213Z","Order":6},{"ID":5285,"Name":"Report
-        a possible data incident","IsActive":true,"DateCreated":"2021-10-06T18:23:10.22Z","DateModified":"2021-10-06T18:23:10.22Z","Order":7},{"ID":5286,"Name":"Other","IsActive":true,"DateCreated":"2021-10-06T18:23:10.227Z","DateModified":"2021-10-06T18:23:10.227Z","Order":8}],"IsRequired":false,"IsUpdatable":false,"Value":"5279","ValueText":"Customer
-        Service Request/ General Inquiry","ChoicesText":"Customer Service Request/
-        General Inquiry","AssociatedItemIDs":[0]},{"ID":3621,"Name":"UIUC-TechSvc-Privacy
-        Data Domains","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"checklist","DataType":"String","Choices":[{"ID":5290,"Name":"General
-        Identification Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.11Z","DateModified":"2021-10-06T18:34:43.11Z","Order":1},{"ID":5291,"Name":"Student
-        and Academic Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.117Z","DateModified":"2021-10-06T18:34:43.117Z","Order":2},{"ID":5292,"Name":"Health
-        and Medical Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.123Z","DateModified":"2021-10-06T18:34:43.123Z","Order":3},{"ID":5293,"Name":"Financial
-        and Consumer Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.13Z","DateModified":"2021-10-06T18:34:43.13Z","Order":4},{"ID":5294,"Name":"Employee
-        and Employment Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.137Z","DateModified":"2021-10-06T18:34:43.137Z","Order":5},{"ID":5295,"Name":"Legal
-        and Technical Data (Non-Personal Data)","IsActive":true,"DateCreated":"2021-10-06T18:34:43.14Z","DateModified":"2021-10-06T18:34:43.14Z","Order":6}],"IsRequired":false,"IsUpdatable":false,"Value":"5290","ValueText":"General
-        Identification Data","ChoicesText":"General Identification Data","AssociatedItemIDs":[0]},{"ID":3620,"Name":"UIUC-TechSvc-Privacy
-        Identifiable Data","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5287,"Name":"Yes","IsActive":true,"DateCreated":"2021-10-06T18:31:36.607Z","DateModified":"2021-10-06T18:31:36.607Z","Order":0},{"ID":5288,"Name":"No","IsActive":true,"DateCreated":"2021-10-06T18:31:36.613Z","DateModified":"2021-10-06T18:31:36.613Z","Order":1},{"ID":5289,"Name":"I
-        don''t know","IsActive":true,"DateCreated":"2021-10-06T18:31:36.637Z","DateModified":"2021-10-06T18:31:36.637Z","Order":2}],"IsRequired":false,"IsUpdatable":false,"Value":"5288","ValueText":"No","ChoicesText":"No","AssociatedItemIDs":[0]},{"ID":3623,"Name":"UIUC-TechSvc-Privacy
-        Area","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5300,"Name":"Research","IsActive":true,"DateCreated":"2021-10-06T18:38:19.52Z","DateModified":"2021-10-06T18:38:19.52Z","Order":1},{"ID":5301,"Name":"Administrative
-        / Operational","IsActive":true,"DateCreated":"2021-10-06T18:38:19.527Z","DateModified":"2021-10-06T18:38:19.527Z","Order":2},{"ID":5302,"Name":"Health
-        / Student / Employee Wellness","IsActive":true,"DateCreated":"2021-10-06T18:38:19.537Z","DateModified":"2021-10-06T18:38:19.537Z","Order":3},{"ID":5303,"Name":"Student
-        / Academic","IsActive":true,"DateCreated":"2021-10-06T18:38:19.543Z","DateModified":"2021-10-06T18:38:19.543Z","Order":4},{"ID":5304,"Name":"Other","IsActive":true,"DateCreated":"2021-10-06T18:38:19.55Z","DateModified":"2021-10-06T18:38:19.55Z","Order":5}],"IsRequired":false,"IsUpdatable":false,"Value":"5300","ValueText":"Research","ChoicesText":"Research","AssociatedItemIDs":[0]},{"ID":3625,"Name":"UIUC-TechSvc-Privacy
-        Affiliation","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5305,"Name":"Yes","IsActive":true,"DateCreated":"2021-10-06T18:42:23.347Z","DateModified":"2021-10-06T18:42:23.347Z","Order":0},{"ID":5306,"Name":"No","IsActive":true,"DateCreated":"2021-10-06T18:42:23.357Z","DateModified":"2021-10-06T18:42:23.357Z","Order":1}],"IsRequired":false,"IsUpdatable":false,"Value":"5305","ValueText":"Yes","ChoicesText":"Yes","AssociatedItemIDs":[0]}],"Attachments":[],"Tasks":[],"Notify":[{"ItemRole":"Responsible","Name":"CLEANED
-        CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Responsible
+        Request","FormID":1069,"FormName":"UIUC-TechSvc-CSOC Incidents","Title":"NewBoo","Description":"","IsRichHtml":false,"Uri":"api/66/tickets/1011312","AccountID":7902,"AccountName":"None/Not
+        Found","SourceID":0,"SourceName":"","StatusID":357,"StatusName":"New","StatusClass":1,"ImpactID":0,"ImpactName":"","UrgencyID":0,"UrgencyName":"","PriorityID":19,"PriorityName":"Low","PriorityOrder":1.0,"SlaID":0,"SlaName":"","IsSlaViolated":false,"IsSlaRespondByViolated":false,"IsSlaResolveByViolated":false,"RespondByDate":"0001-01-01T00:00:00","ResolveByDate":"0001-01-01T00:00:00","SlaBeginDate":"0001-01-01T00:00:00","IsOnHold":false,"PlacedOnHoldDate":"0001-01-01T00:00:00","GoesOffHoldDate":"0001-01-01T00:00:00","CreatedDate":"2024-01-31T18:40:32.353Z","CreatedUid":"a68e93bc-e406-ee11-87dd-0050f2e6c034","CreatedFullName":"Security
+        SOAR API Service Account","CreatedEmail":"","ModifiedDate":"2024-01-31T18:51:30.607Z","ModifiedUid":"a68e93bc-e406-ee11-87dd-0050f2e6c034","ModifiedFullName":"Security
+        SOAR API Service Account","RequestorName":"CLEANED CLEANED","RequestorFirstName":"CLEANED","RequestorLastName":"CLEANED","RequestorEmail":"CLEANED@illinois.edu","RequestorPhone":"","RequestorUid":"b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7","ActualMinutes":0,"EstimatedMinutes":0,"DaysOld":0,"StartDate":null,"EndDate":null,"ResponsibleUid":null,"ResponsibleFullName":"Unassigned","ResponsibleEmail":"","ResponsibleGroupID":787,"ResponsibleGroupName":"UIUC-TechServices-Cybersecurity
+        Developers","RespondedDate":"0001-01-01T00:00:00","RespondedUid":null,"RespondedFullName":"","CompletedDate":"0001-01-01T00:00:00","CompletedUid":null,"CompletedFullName":"","ReviewerUid":null,"ReviewerFullName":"","ReviewerEmail":"","ReviewingGroupID":0,"ReviewingGroupName":"","TimeBudget":0.0,"ExpensesBudget":0.0,"TimeBudgetUsed":0.0,"ExpensesBudgetUsed":0.0,"IsConvertedToTask":false,"ConvertedToTaskDate":"0001-01-01T00:00:00","ConvertedToTaskUid":null,"ConvertedToTaskFullName":"","TaskProjectID":0,"TaskProjectName":"","TaskPlanID":0,"TaskPlanName":"","TaskID":0,"TaskTitle":"","TaskStartDate":"0001-01-01T00:00:00","TaskEndDate":"0001-01-01T00:00:00","TaskPercentComplete":0,"LocationID":0,"LocationName":"","LocationRoomID":0,"LocationRoomName":"","RefCode":"","ServiceID":0,"ServiceName":"None","ServiceOfferingID":0,"ServiceOfferingName":"None","ServiceCategoryID":0,"ServiceCategoryName":"None","ArticleID":0,"ArticleSubject":"","ArticleStatus":0,"ArticleCategoryPathNames":"","ArticleAppID":0,"ArticleShortcutID":null,"AppID":66,"Attributes":[{"ID":4902,"Name":"UIUC-TechSvc-CSOC
+        Incident Severity","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":10539,"Name":"To
+        Be Determined","IsActive":true,"DateCreated":"2023-04-17T20:47:47.447Z","DateModified":"2023-04-17T20:47:47.447Z","Order":0},{"ID":10541,"Name":"Non-Event","IsActive":true,"DateCreated":"2023-04-17T20:48:18.213Z","DateModified":"2023-04-17T20:48:33.57Z","Order":1},{"ID":10540,"Name":"Low
+        - Minor","IsActive":true,"DateCreated":"2023-04-17T20:48:05.88Z","DateModified":"2023-04-17T20:48:24.127Z","Order":2},{"ID":10203,"Name":"Medium
+        - Moderate","IsActive":true,"DateCreated":"2023-03-13T19:34:05.207Z","DateModified":"2023-04-17T20:49:23.907Z","Order":3},{"ID":10204,"Name":"High
+        - Serious","IsActive":true,"DateCreated":"2023-03-13T19:34:05.217Z","DateModified":"2023-04-17T20:49:18.803Z","Order":4},{"ID":10542,"Name":"Critical
+        - Major","IsActive":true,"DateCreated":"2023-04-17T20:49:12.407Z","DateModified":"2023-04-17T20:49:12.407Z","Order":5},{"ID":15624,"Name":"Mutli-Campus","IsActive":true,"DateCreated":"2023-12-05T19:40:38.35Z","DateModified":"2023-12-05T19:40:38.35Z","Order":6}],"IsRequired":false,"IsUpdatable":true,"Value":"10539","ValueText":"To
+        Be Determined","ChoicesText":"To Be Determined","AssociatedItemIDs":[0]},{"ID":4363,"Name":"UIUC-TechSvc-Security
+        TLP","Order":0,"Description":"Traffic Light Protocol sharing classification
+        - See also https://wiki.illinois.edu/wiki/display/SEC/Traffic+Light+Protocol+-TLP","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":8175,"Name":"TLP:CLEAR","IsActive":true,"DateCreated":"2022-06-29T20:23:50.033Z","DateModified":"2023-09-14T17:33:23.823Z","Order":0},{"ID":8174,"Name":"TLP:GREEN","IsActive":true,"DateCreated":"2022-06-29T20:23:49.927Z","DateModified":"2022-06-29T20:23:49.927Z","Order":1},{"ID":8173,"Name":"TLP:AMBER","IsActive":true,"DateCreated":"2022-06-29T20:23:49.827Z","DateModified":"2022-06-29T20:23:49.827Z","Order":2},{"ID":14037,"Name":"TLP:AMBER+STRICT","IsActive":true,"DateCreated":"2023-09-14T17:33:09.307Z","DateModified":"2023-09-14T17:33:09.307Z","Order":3},{"ID":8172,"Name":"TLP:RED","IsActive":true,"DateCreated":"2022-06-29T20:23:49.723Z","DateModified":"2023-09-14T17:33:16.707Z","Order":4}],"IsRequired":false,"IsUpdatable":true,"Value":"8172","ValueText":"TLP:RED","ChoicesText":"TLP:RED","AssociatedItemIDs":[0]}],"Attachments":[],"Tasks":[],"Notify":[{"ItemRole":"Responsible
         Group","Name":"UIUC-TechServices-Cybersecurity Developers","Initials":null,"Value":"787","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Requestor","Name":"CLEANED
         CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null}],"WorkflowID":0,"WorkflowConfigurationID":0,"WorkflowName":""}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '8736'
+      - '5594'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 15 Jun 2023 19:52:18 GMT
+      - Wed, 31 Jan 2024 18:51:29 GMT
       Expires:
       - '-1'
       Pragma:
@@ -395,7 +305,7 @@ interactions:
       X-RateLimit-Remaining:
       - '59'
       X-RateLimit-Reset:
-      - Thu, 15 Jun 2023 19:53:19 GMT
+      - Wed, 31 Jan 2024 18:52:30 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -403,9 +313,9 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - e6892492-04c8-4919-b5d2-d9095f4f56ef
+      - '8883593399497794147'
       X-TDX-UID:
-      - 0bfec2fa-e406-ee11-87dd-0050f2e6c034
+      - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
       - IE=edge
     status:

--- a/cassettes/test_reassign_user.yaml
+++ b/cassettes/test_reassign_user.yaml
@@ -19,7 +19,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAPVri2QC/0ut9MpIck/O9M/08gyt8jT0y/Qs9swLMk129jTzzC6ICHP2stRLrfTKSfVwzPTP
+        H4sIALWWumUC/0ut9MpIck/O9M/08gyt8jT0y/Qs9swLMk129jTzzC6ICHP2stRLrfTKSfVwzPTP
         8jT0dUmv8A/xLPd1cbLUy48KSdI1T8mpKvRISQ5394kI8851LDXLNfQqDTGqjE8vNffUDYn0czML
         yQYA/EJXWGkAAAA=
     headers:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 15 Jun 2023 19:52:19 GMT
+      - Wed, 31 Jan 2024 18:51:31 GMT
       Expires:
       - '-1'
       Pragma:
@@ -46,13 +46,13 @@ interactions:
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '50'
+      - '58'
       X-RateLimit-Reset:
-      - Thu, 15 Jun 2023 19:52:54 GMT
+      - Wed, 31 Jan 2024 18:52:28 GMT
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - bc90a26f-ed8a-4c98-a2b6-2f90ebe6e3da
+      - '4659215183223390867'
       X-UA-Compatible:
       - IE=edge
     status:
@@ -77,7 +77,7 @@ interactions:
     uri: https://help.uillinois.edu/SBTDWebApi/api/people/lookup?searchText=thor2&maxResults=1
   response:
     body:
-      string: '[{"UID": "54b3b2ee-90c9-ea11-a81d-000d3a8ea9f7", "ReferenceID": 48436,
+      string: '[{"UID": "b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7", "ReferenceID": 48141,
         "BEID": "0f7df9ca-3924-4806-8adc-6e880a796ddc", "BEIDInt": 2, "IsActive":
         true, "IsConfidential": false, "UserName": "", "FullName": "Jane Foster",
         "FirstName": "Jane", "LastName": "Foster", "MiddleName": null, "Salutation":
@@ -104,11 +104,11 @@ interactions:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '1563'
+      - '1567'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 15 Jun 2023 19:52:20 GMT
+      - Wed, 31 Jan 2024 18:51:32 GMT
       Expires:
       - '-1'
       Pragma:
@@ -122,7 +122,7 @@ interactions:
       X-RateLimit-Remaining:
       - '74'
       X-RateLimit-Reset:
-      - Thu, 15 Jun 2023 19:52:31 GMT
+      - Wed, 31 Jan 2024 18:51:42 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -130,9 +130,9 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - a1371e14-ae59-473c-9dad-3707b4ea98e3
+      - '8778399771814605818'
       X-TDX-UID:
-      - 0bfec2fa-e406-ee11-87dd-0050f2e6c034
+      - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
       - IE=edge
     status:
@@ -154,57 +154,36 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://help.uillinois.edu/SBTDWebApi/api/66/tickets/564073
+    uri: https://help.uillinois.edu/SBTDWebApi/api/66/tickets/1011312
   response:
     body:
-      string: '{"ID":564073,"ParentID":0,"ParentTitle":"","ParentClass":0,"TypeID":312,"TypeName":"Security
+      string: '{"ID":1011312,"ParentID":0,"ParentTitle":"","ParentClass":0,"TypeID":312,"TypeName":"Security
         Support","TypeCategoryID":89,"TypeCategoryName":"UIUC-Privacy and Cybersecurity","Classification":46,"ClassificationName":"Service
-        Request","FormID":693,"FormName":"UIUC-TechServices-Privacy New Request","Title":"NewBoo","Description":"Test
-        request","IsRichHtml":false,"Uri":"api/66/tickets/564073","AccountID":7902,"AccountName":"None/Not
-        Found","SourceID":0,"SourceName":"","StatusID":360,"StatusName":"Resolved","StatusClass":3,"ImpactID":0,"ImpactName":"","UrgencyID":0,"UrgencyName":"","PriorityID":19,"PriorityName":"Low","PriorityOrder":1.0,"SlaID":0,"SlaName":"","IsSlaViolated":false,"IsSlaRespondByViolated":false,"IsSlaResolveByViolated":false,"RespondByDate":"0001-01-01T00:00:00","ResolveByDate":"0001-01-01T00:00:00","SlaBeginDate":"0001-01-01T00:00:00","IsOnHold":false,"PlacedOnHoldDate":"0001-01-01T00:00:00","GoesOffHoldDate":"0001-01-01T00:00:00","CreatedDate":"2022-12-01T17:12:16.05Z","CreatedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","CreatedFullName":"Tech
-        Services Security API","CreatedEmail":"","ModifiedDate":"2023-06-15T19:52:14.713Z","ModifiedUid":"0bfec2fa-e406-ee11-87dd-0050f2e6c034","ModifiedFullName":"Security
-        SOAR API Service Account","RequestorName":"CLEANED CLEANED","RequestorFirstName":"CLEANED","RequestorLastName":"CLEANED","RequestorEmail":"CLEANED@illinois.edu","RequestorPhone":"217-300-5753","RequestorUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ActualMinutes":0,"EstimatedMinutes":0,"DaysOld":14,"StartDate":null,"EndDate":null,"ResponsibleUid":"bbd30493-8ec9-ea11-a81d-000d3a8ea9f7","ResponsibleFullName":"CLEANED
-        CLEANED","ResponsibleEmail":"CLEANED@illinois.edu","ResponsibleGroupID":787,"ResponsibleGroupName":"UIUC-TechServices-Cybersecurity
-        Developers","RespondedDate":"2022-12-01T17:12:16.05Z","RespondedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","RespondedFullName":"Tech
-        Services Security API","CompletedDate":"2022-12-15T16:42:00.94Z","CompletedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","CompletedFullName":"Tech
-        Services Security API","ReviewerUid":null,"ReviewerFullName":"","ReviewerEmail":"","ReviewingGroupID":0,"ReviewingGroupName":"","TimeBudget":0.0,"ExpensesBudget":0.0,"TimeBudgetUsed":0.0,"ExpensesBudgetUsed":0.0,"IsConvertedToTask":false,"ConvertedToTaskDate":"0001-01-01T00:00:00","ConvertedToTaskUid":null,"ConvertedToTaskFullName":"","TaskProjectID":0,"TaskProjectName":"","TaskPlanID":0,"TaskPlanName":"","TaskID":0,"TaskTitle":"","TaskStartDate":"0001-01-01T00:00:00","TaskEndDate":"0001-01-01T00:00:00","TaskPercentComplete":0,"LocationID":0,"LocationName":"","LocationRoomID":0,"LocationRoomName":"","RefCode":"","ServiceID":0,"ServiceName":"None","ServiceOfferingID":0,"ServiceOfferingName":"None","ServiceCategoryID":0,"ServiceCategoryName":"None","ArticleID":0,"ArticleSubject":"","ArticleStatus":0,"ArticleCategoryPathNames":"","ArticleAppID":0,"ArticleShortcutID":null,"AppID":66,"Attributes":[{"ID":3618,"Name":"UIUC-TechSvc-Privacy
-        Nature of Request","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":5279,"Name":"Customer
-        Service Request/ General Inquiry","IsActive":true,"DateCreated":"2021-10-06T18:23:10.183Z","DateModified":"2021-10-06T18:23:10.183Z","Order":1},{"ID":5280,"Name":"Request
-        a new privacy service, project or capability","IsActive":true,"DateCreated":"2021-10-06T18:23:10.19Z","DateModified":"2021-10-06T18:23:10.19Z","Order":2},{"ID":5281,"Name":"Privacy
-        Consultation","IsActive":true,"DateCreated":"2021-10-06T18:23:10.193Z","DateModified":"2021-10-06T18:23:10.193Z","Order":3},{"ID":5282,"Name":"New
-        purchase / third party product or service review","IsActive":true,"DateCreated":"2021-10-06T18:23:10.2Z","DateModified":"2021-10-06T18:23:10.2Z","Order":4},{"ID":5283,"Name":"Compliance-related
-        question","IsActive":true,"DateCreated":"2021-10-06T18:23:10.207Z","DateModified":"2021-10-06T18:23:10.207Z","Order":5},{"ID":5284,"Name":"Request
-        a privacy impact assessment","IsActive":true,"DateCreated":"2021-10-06T18:23:10.213Z","DateModified":"2021-10-06T18:23:10.213Z","Order":6},{"ID":5285,"Name":"Report
-        a possible data incident","IsActive":true,"DateCreated":"2021-10-06T18:23:10.22Z","DateModified":"2021-10-06T18:23:10.22Z","Order":7},{"ID":5286,"Name":"Other","IsActive":true,"DateCreated":"2021-10-06T18:23:10.227Z","DateModified":"2021-10-06T18:23:10.227Z","Order":8}],"IsRequired":false,"IsUpdatable":false,"Value":"5279","ValueText":"Customer
-        Service Request/ General Inquiry","ChoicesText":"Customer Service Request/
-        General Inquiry","AssociatedItemIDs":[0]},{"ID":3621,"Name":"UIUC-TechSvc-Privacy
-        Data Domains","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"checklist","DataType":"String","Choices":[{"ID":5290,"Name":"General
-        Identification Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.11Z","DateModified":"2021-10-06T18:34:43.11Z","Order":1},{"ID":5291,"Name":"Student
-        and Academic Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.117Z","DateModified":"2021-10-06T18:34:43.117Z","Order":2},{"ID":5292,"Name":"Health
-        and Medical Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.123Z","DateModified":"2021-10-06T18:34:43.123Z","Order":3},{"ID":5293,"Name":"Financial
-        and Consumer Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.13Z","DateModified":"2021-10-06T18:34:43.13Z","Order":4},{"ID":5294,"Name":"Employee
-        and Employment Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.137Z","DateModified":"2021-10-06T18:34:43.137Z","Order":5},{"ID":5295,"Name":"Legal
-        and Technical Data (Non-Personal Data)","IsActive":true,"DateCreated":"2021-10-06T18:34:43.14Z","DateModified":"2021-10-06T18:34:43.14Z","Order":6}],"IsRequired":false,"IsUpdatable":false,"Value":"5290","ValueText":"General
-        Identification Data","ChoicesText":"General Identification Data","AssociatedItemIDs":[0]},{"ID":3620,"Name":"UIUC-TechSvc-Privacy
-        Identifiable Data","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5287,"Name":"Yes","IsActive":true,"DateCreated":"2021-10-06T18:31:36.607Z","DateModified":"2021-10-06T18:31:36.607Z","Order":0},{"ID":5288,"Name":"No","IsActive":true,"DateCreated":"2021-10-06T18:31:36.613Z","DateModified":"2021-10-06T18:31:36.613Z","Order":1},{"ID":5289,"Name":"I
-        don''t know","IsActive":true,"DateCreated":"2021-10-06T18:31:36.637Z","DateModified":"2021-10-06T18:31:36.637Z","Order":2}],"IsRequired":false,"IsUpdatable":false,"Value":"5288","ValueText":"No","ChoicesText":"No","AssociatedItemIDs":[0]},{"ID":3623,"Name":"UIUC-TechSvc-Privacy
-        Area","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5300,"Name":"Research","IsActive":true,"DateCreated":"2021-10-06T18:38:19.52Z","DateModified":"2021-10-06T18:38:19.52Z","Order":1},{"ID":5301,"Name":"Administrative
-        / Operational","IsActive":true,"DateCreated":"2021-10-06T18:38:19.527Z","DateModified":"2021-10-06T18:38:19.527Z","Order":2},{"ID":5302,"Name":"Health
-        / Student / Employee Wellness","IsActive":true,"DateCreated":"2021-10-06T18:38:19.537Z","DateModified":"2021-10-06T18:38:19.537Z","Order":3},{"ID":5303,"Name":"Student
-        / Academic","IsActive":true,"DateCreated":"2021-10-06T18:38:19.543Z","DateModified":"2021-10-06T18:38:19.543Z","Order":4},{"ID":5304,"Name":"Other","IsActive":true,"DateCreated":"2021-10-06T18:38:19.55Z","DateModified":"2021-10-06T18:38:19.55Z","Order":5}],"IsRequired":false,"IsUpdatable":false,"Value":"5300","ValueText":"Research","ChoicesText":"Research","AssociatedItemIDs":[0]},{"ID":3625,"Name":"UIUC-TechSvc-Privacy
-        Affiliation","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5305,"Name":"Yes","IsActive":true,"DateCreated":"2021-10-06T18:42:23.347Z","DateModified":"2021-10-06T18:42:23.347Z","Order":0},{"ID":5306,"Name":"No","IsActive":true,"DateCreated":"2021-10-06T18:42:23.357Z","DateModified":"2021-10-06T18:42:23.357Z","Order":1}],"IsRequired":false,"IsUpdatable":false,"Value":"5305","ValueText":"Yes","ChoicesText":"Yes","AssociatedItemIDs":[0]}],"Attachments":[],"Tasks":[],"Notify":[{"ItemRole":"Responsible","Name":"CLEANED
-        CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Responsible
+        Request","FormID":1069,"FormName":"UIUC-TechSvc-CSOC Incidents","Title":"NewBoo","Description":"","IsRichHtml":false,"Uri":"api/66/tickets/1011312","AccountID":7902,"AccountName":"None/Not
+        Found","SourceID":0,"SourceName":"","StatusID":357,"StatusName":"New","StatusClass":1,"ImpactID":0,"ImpactName":"","UrgencyID":0,"UrgencyName":"","PriorityID":19,"PriorityName":"Low","PriorityOrder":1.0,"SlaID":0,"SlaName":"","IsSlaViolated":false,"IsSlaRespondByViolated":false,"IsSlaResolveByViolated":false,"RespondByDate":"0001-01-01T00:00:00","ResolveByDate":"0001-01-01T00:00:00","SlaBeginDate":"0001-01-01T00:00:00","IsOnHold":false,"PlacedOnHoldDate":"0001-01-01T00:00:00","GoesOffHoldDate":"0001-01-01T00:00:00","CreatedDate":"2024-01-31T18:40:32.353Z","CreatedUid":"a68e93bc-e406-ee11-87dd-0050f2e6c034","CreatedFullName":"Security
+        SOAR API Service Account","CreatedEmail":"","ModifiedDate":"2024-01-31T18:51:30.607Z","ModifiedUid":"a68e93bc-e406-ee11-87dd-0050f2e6c034","ModifiedFullName":"Security
+        SOAR API Service Account","RequestorName":"CLEANED CLEANED","RequestorFirstName":"CLEANED","RequestorLastName":"CLEANED","RequestorEmail":"CLEANED@illinois.edu","RequestorPhone":"","RequestorUid":"b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7","ActualMinutes":0,"EstimatedMinutes":0,"DaysOld":0,"StartDate":null,"EndDate":null,"ResponsibleUid":null,"ResponsibleFullName":"Unassigned","ResponsibleEmail":"","ResponsibleGroupID":787,"ResponsibleGroupName":"UIUC-TechServices-Cybersecurity
+        Developers","RespondedDate":"0001-01-01T00:00:00","RespondedUid":null,"RespondedFullName":"","CompletedDate":"0001-01-01T00:00:00","CompletedUid":null,"CompletedFullName":"","ReviewerUid":null,"ReviewerFullName":"","ReviewerEmail":"","ReviewingGroupID":0,"ReviewingGroupName":"","TimeBudget":0.0,"ExpensesBudget":0.0,"TimeBudgetUsed":0.0,"ExpensesBudgetUsed":0.0,"IsConvertedToTask":false,"ConvertedToTaskDate":"0001-01-01T00:00:00","ConvertedToTaskUid":null,"ConvertedToTaskFullName":"","TaskProjectID":0,"TaskProjectName":"","TaskPlanID":0,"TaskPlanName":"","TaskID":0,"TaskTitle":"","TaskStartDate":"0001-01-01T00:00:00","TaskEndDate":"0001-01-01T00:00:00","TaskPercentComplete":0,"LocationID":0,"LocationName":"","LocationRoomID":0,"LocationRoomName":"","RefCode":"","ServiceID":0,"ServiceName":"None","ServiceOfferingID":0,"ServiceOfferingName":"None","ServiceCategoryID":0,"ServiceCategoryName":"None","ArticleID":0,"ArticleSubject":"","ArticleStatus":0,"ArticleCategoryPathNames":"","ArticleAppID":0,"ArticleShortcutID":null,"AppID":66,"Attributes":[{"ID":4902,"Name":"UIUC-TechSvc-CSOC
+        Incident Severity","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":10539,"Name":"To
+        Be Determined","IsActive":true,"DateCreated":"2023-04-17T20:47:47.447Z","DateModified":"2023-04-17T20:47:47.447Z","Order":0},{"ID":10541,"Name":"Non-Event","IsActive":true,"DateCreated":"2023-04-17T20:48:18.213Z","DateModified":"2023-04-17T20:48:33.57Z","Order":1},{"ID":10540,"Name":"Low
+        - Minor","IsActive":true,"DateCreated":"2023-04-17T20:48:05.88Z","DateModified":"2023-04-17T20:48:24.127Z","Order":2},{"ID":10203,"Name":"Medium
+        - Moderate","IsActive":true,"DateCreated":"2023-03-13T19:34:05.207Z","DateModified":"2023-04-17T20:49:23.907Z","Order":3},{"ID":10204,"Name":"High
+        - Serious","IsActive":true,"DateCreated":"2023-03-13T19:34:05.217Z","DateModified":"2023-04-17T20:49:18.803Z","Order":4},{"ID":10542,"Name":"Critical
+        - Major","IsActive":true,"DateCreated":"2023-04-17T20:49:12.407Z","DateModified":"2023-04-17T20:49:12.407Z","Order":5},{"ID":15624,"Name":"Mutli-Campus","IsActive":true,"DateCreated":"2023-12-05T19:40:38.35Z","DateModified":"2023-12-05T19:40:38.35Z","Order":6}],"IsRequired":false,"IsUpdatable":true,"Value":"10539","ValueText":"To
+        Be Determined","ChoicesText":"To Be Determined","AssociatedItemIDs":[0]},{"ID":4363,"Name":"UIUC-TechSvc-Security
+        TLP","Order":0,"Description":"Traffic Light Protocol sharing classification
+        - See also https://wiki.illinois.edu/wiki/display/SEC/Traffic+Light+Protocol+-TLP","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":8175,"Name":"TLP:CLEAR","IsActive":true,"DateCreated":"2022-06-29T20:23:50.033Z","DateModified":"2023-09-14T17:33:23.823Z","Order":0},{"ID":8174,"Name":"TLP:GREEN","IsActive":true,"DateCreated":"2022-06-29T20:23:49.927Z","DateModified":"2022-06-29T20:23:49.927Z","Order":1},{"ID":8173,"Name":"TLP:AMBER","IsActive":true,"DateCreated":"2022-06-29T20:23:49.827Z","DateModified":"2022-06-29T20:23:49.827Z","Order":2},{"ID":14037,"Name":"TLP:AMBER+STRICT","IsActive":true,"DateCreated":"2023-09-14T17:33:09.307Z","DateModified":"2023-09-14T17:33:09.307Z","Order":3},{"ID":8172,"Name":"TLP:RED","IsActive":true,"DateCreated":"2022-06-29T20:23:49.723Z","DateModified":"2023-09-14T17:33:16.707Z","Order":4}],"IsRequired":false,"IsUpdatable":true,"Value":"8172","ValueText":"TLP:RED","ChoicesText":"TLP:RED","AssociatedItemIDs":[0]}],"Attachments":[],"Tasks":[],"Notify":[{"ItemRole":"Responsible
         Group","Name":"UIUC-TechServices-Cybersecurity Developers","Initials":null,"Value":"787","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Requestor","Name":"CLEANED
         CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null}],"WorkflowID":0,"WorkflowConfigurationID":0,"WorkflowName":""}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '8736'
+      - '5594'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 15 Jun 2023 19:52:21 GMT
+      - Wed, 31 Jan 2024 18:51:32 GMT
       Expires:
       - '-1'
       Pragma:
@@ -218,7 +197,7 @@ interactions:
       X-RateLimit-Remaining:
       - '58'
       X-RateLimit-Reset:
-      - Thu, 15 Jun 2023 19:53:19 GMT
+      - Wed, 31 Jan 2024 18:52:30 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -226,110 +205,66 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - 148839d1-e31e-4b7f-bf0a-2f26d9649121
+      - '8077045183216944231'
       X-TDX-UID:
-      - 0bfec2fa-e406-ee11-87dd-0050f2e6c034
+      - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
       - IE=edge
     status:
       code: 200
       message: OK
 - request:
-    body: '{"ID": 564073, "TypeID": 312, "TypeName": "Security Support", "TypeCategoryID":
+    body: '{"ID": 1011312, "TypeID": 312, "TypeName": "Security Support", "TypeCategoryID":
       89, "TypeCategoryName": "UIUC-Privacy and Cybersecurity", "Classification":
-      46, "ClassificationName": "Service Request", "FormID": 693, "FormName": "UIUC-TechServices-Privacy
-      New Request", "Title": "NewBoo", "Description": "Test request", "Uri": "api/66/tickets/564073",
-      "AccountID": 7902, "AccountName": "None/Not Found", "StatusID": 360, "StatusName":
-      "Resolved", "StatusClass": 3, "PriorityID": 19, "PriorityName": "Low", "PriorityOrder":
-      1.0, "CreatedDate": "2022-12-01T17:12:16+0000", "CreatedUid": "3c3caa7d-c365-ed11-ade6-0050f2e6378b",
-      "CreatedFullName": "Tech Services Security API", "ModifiedDate": "2023-06-15T19:52:14+0000",
-      "ModifiedUid": "0bfec2fa-e406-ee11-87dd-0050f2e6c034", "ModifiedFullName": "Security
+      46, "ClassificationName": "Service Request", "FormID": 1069, "FormName": "UIUC-TechSvc-CSOC
+      Incidents", "Title": "NewBoo", "Uri": "api/66/tickets/1011312", "AccountID":
+      7902, "AccountName": "None/Not Found", "StatusID": 357, "StatusName": "New",
+      "StatusClass": 1, "PriorityID": 19, "PriorityName": "Low", "PriorityOrder":
+      1.0, "CreatedDate": "2024-01-31T18:40:32+0000", "CreatedUid": "a68e93bc-e406-ee11-87dd-0050f2e6c034",
+      "CreatedFullName": "Security SOAR API Service Account", "ModifiedDate": "2024-01-31T18:51:30+0000",
+      "ModifiedUid": "a68e93bc-e406-ee11-87dd-0050f2e6c034", "ModifiedFullName": "Security
       SOAR API Service Account", "RequestorName": "CLEANED CLEANED", "RequestorFirstName":
       "CLEANED", "RequestorLastName": "CLEANED", "RequestorEmail": "CLEANED@illinois.edu",
-      "RequestorPhone": "217-300-5753", "RequestorUid": "a3e79204-8fc9-ea11-a81d-000d3a8ea9f7",
-      "DaysOld": 14, "ResponsibleUid": "54b3b2ee-90c9-ea11-a81d-000d3a8ea9f7", "ResponsibleFullName":
-      "CLEANED CLEANED", "ResponsibleEmail": "CLEANED@illinois.edu", "ResponsibleGroupID":
-      787, "ResponsibleGroupName": "UIUC-TechServices-Cybersecurity Developers", "RespondedDate":
-      "2022-12-01T17:12:16+0000", "RespondedUid": "3c3caa7d-c365-ed11-ade6-0050f2e6378b",
-      "RespondedFullName": "Tech Services Security API", "CompletedDate": "2022-12-15T16:42:00+0000",
-      "CompletedUid": "3c3caa7d-c365-ed11-ade6-0050f2e6378b", "CompletedFullName":
-      "Tech Services Security API", "ServiceName": "None", "ServiceOfferingName":
-      "None", "ServiceCategoryName": "None", "AppID": 66, "Attributes": [{"ID": 3618,
-      "Name": "UIUC-TechSvc-Privacy Nature of Request", "Order": 0, "Description":
-      "", "SectionID": 0, "SectionName": null, "FieldType": "dropdown", "DataType":
-      "String", "Choices": [{"ID": 5279, "Name": "Customer Service Request/ General
-      Inquiry", "IsActive": true, "DateCreated": "2021-10-06T18:23:10.183Z", "DateModified":
-      "2021-10-06T18:23:10.183Z", "Order": 1}, {"ID": 5280, "Name": "Request a new
-      privacy service, project or capability", "IsActive": true, "DateCreated": "2021-10-06T18:23:10.19Z",
-      "DateModified": "2021-10-06T18:23:10.19Z", "Order": 2}, {"ID": 5281, "Name":
-      "Privacy Consultation", "IsActive": true, "DateCreated": "2021-10-06T18:23:10.193Z",
-      "DateModified": "2021-10-06T18:23:10.193Z", "Order": 3}, {"ID": 5282, "Name":
-      "New purchase / third party product or service review", "IsActive": true, "DateCreated":
-      "2021-10-06T18:23:10.2Z", "DateModified": "2021-10-06T18:23:10.2Z", "Order":
-      4}, {"ID": 5283, "Name": "Compliance-related question", "IsActive": true, "DateCreated":
-      "2021-10-06T18:23:10.207Z", "DateModified": "2021-10-06T18:23:10.207Z", "Order":
-      5}, {"ID": 5284, "Name": "Request a privacy impact assessment", "IsActive":
-      true, "DateCreated": "2021-10-06T18:23:10.213Z", "DateModified": "2021-10-06T18:23:10.213Z",
-      "Order": 6}, {"ID": 5285, "Name": "Report a possible data incident", "IsActive":
-      true, "DateCreated": "2021-10-06T18:23:10.22Z", "DateModified": "2021-10-06T18:23:10.22Z",
-      "Order": 7}, {"ID": 5286, "Name": "Other", "IsActive": true, "DateCreated":
-      "2021-10-06T18:23:10.227Z", "DateModified": "2021-10-06T18:23:10.227Z", "Order":
-      8}], "IsRequired": false, "IsUpdatable": false, "Value": "5279", "ValueText":
-      "Customer Service Request/ General Inquiry", "ChoicesText": "Customer Service
-      Request/ General Inquiry", "AssociatedItemIDs": [0]}, {"ID": 3621, "Name": "UIUC-TechSvc-Privacy
-      Data Domains", "Order": 0, "Description": "", "SectionID": 0, "SectionName":
-      null, "FieldType": "checklist", "DataType": "String", "Choices": [{"ID": 5290,
-      "Name": "General Identification Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.11Z",
-      "DateModified": "2021-10-06T18:34:43.11Z", "Order": 1}, {"ID": 5291, "Name":
-      "Student and Academic Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.117Z",
-      "DateModified": "2021-10-06T18:34:43.117Z", "Order": 2}, {"ID": 5292, "Name":
-      "Health and Medical Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.123Z",
-      "DateModified": "2021-10-06T18:34:43.123Z", "Order": 3}, {"ID": 5293, "Name":
-      "Financial and Consumer Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.13Z",
-      "DateModified": "2021-10-06T18:34:43.13Z", "Order": 4}, {"ID": 5294, "Name":
-      "Employee and Employment Data", "IsActive": true, "DateCreated": "2021-10-06T18:34:43.137Z",
-      "DateModified": "2021-10-06T18:34:43.137Z", "Order": 5}, {"ID": 5295, "Name":
-      "Legal and Technical Data (Non-Personal Data)", "IsActive": true, "DateCreated":
-      "2021-10-06T18:34:43.14Z", "DateModified": "2021-10-06T18:34:43.14Z", "Order":
-      6}], "IsRequired": false, "IsUpdatable": false, "Value": "5290", "ValueText":
-      "General Identification Data", "ChoicesText": "General Identification Data",
-      "AssociatedItemIDs": [0]}, {"ID": 3620, "Name": "UIUC-TechSvc-Privacy Identifiable
-      Data", "Order": 0, "Description": "", "SectionID": 0, "SectionName": null, "FieldType":
-      "vradio", "DataType": "String", "Choices": [{"ID": 5287, "Name": "Yes", "IsActive":
-      true, "DateCreated": "2021-10-06T18:31:36.607Z", "DateModified": "2021-10-06T18:31:36.607Z",
-      "Order": 0}, {"ID": 5288, "Name": "No", "IsActive": true, "DateCreated": "2021-10-06T18:31:36.613Z",
-      "DateModified": "2021-10-06T18:31:36.613Z", "Order": 1}, {"ID": 5289, "Name":
-      "I don''t know", "IsActive": true, "DateCreated": "2021-10-06T18:31:36.637Z",
-      "DateModified": "2021-10-06T18:31:36.637Z", "Order": 2}], "IsRequired": false,
-      "IsUpdatable": false, "Value": "5288", "ValueText": "No", "ChoicesText": "No",
-      "AssociatedItemIDs": [0]}, {"ID": 3623, "Name": "UIUC-TechSvc-Privacy Area",
-      "Order": 0, "Description": "", "SectionID": 0, "SectionName": null, "FieldType":
-      "vradio", "DataType": "String", "Choices": [{"ID": 5300, "Name": "Research",
-      "IsActive": true, "DateCreated": "2021-10-06T18:38:19.52Z", "DateModified":
-      "2021-10-06T18:38:19.52Z", "Order": 1}, {"ID": 5301, "Name": "Administrative
-      / Operational", "IsActive": true, "DateCreated": "2021-10-06T18:38:19.527Z",
-      "DateModified": "2021-10-06T18:38:19.527Z", "Order": 2}, {"ID": 5302, "Name":
-      "Health / Student / Employee Wellness", "IsActive": true, "DateCreated": "2021-10-06T18:38:19.537Z",
-      "DateModified": "2021-10-06T18:38:19.537Z", "Order": 3}, {"ID": 5303, "Name":
-      "Student / Academic", "IsActive": true, "DateCreated": "2021-10-06T18:38:19.543Z",
-      "DateModified": "2021-10-06T18:38:19.543Z", "Order": 4}, {"ID": 5304, "Name":
-      "Other", "IsActive": true, "DateCreated": "2021-10-06T18:38:19.55Z", "DateModified":
-      "2021-10-06T18:38:19.55Z", "Order": 5}], "IsRequired": false, "IsUpdatable":
-      false, "Value": "5300", "ValueText": "Research", "ChoicesText": "Research",
-      "AssociatedItemIDs": [0]}, {"ID": 3625, "Name": "UIUC-TechSvc-Privacy Affiliation",
-      "Order": 0, "Description": "", "SectionID": 0, "SectionName": null, "FieldType":
-      "vradio", "DataType": "String", "Choices": [{"ID": 5305, "Name": "Yes", "IsActive":
-      true, "DateCreated": "2021-10-06T18:42:23.347Z", "DateModified": "2021-10-06T18:42:23.347Z",
-      "Order": 0}, {"ID": 5306, "Name": "No", "IsActive": true, "DateCreated": "2021-10-06T18:42:23.357Z",
-      "DateModified": "2021-10-06T18:42:23.357Z", "Order": 1}], "IsRequired": false,
-      "IsUpdatable": false, "Value": "5305", "ValueText": "Yes", "ChoicesText": "Yes",
-      "AssociatedItemIDs": [0]}], "Attachments": [], "Tasks": [], "Notify": [{"ItemRole":
-      "Responsible", "Name": "CLEANED CLEANED", "Initials": null, "Value": "CLEANED@illinois.edu",
-      "RefValue": 0, "ProfileImageFileName": null}, {"ItemRole": "Responsible Group",
-      "Name": "UIUC-TechServices-Cybersecurity Developers", "Initials": null, "Value":
-      "787", "RefValue": 0, "ProfileImageFileName": null}, {"ItemRole": "Requestor",
-      "Name": "CLEANED CLEANED", "Initials": null, "Value": "CLEANED@illinois.edu",
-      "RefValue": 0, "ProfileImageFileName": null}]}'
+      "RequestorUid": "b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7", "ResponsibleUid": "b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7",
+      "ResponsibleFullName": "Unassigned", "ResponsibleGroupID": 787, "ResponsibleGroupName":
+      "UIUC-TechServices-Cybersecurity Developers", "ServiceName": "None", "ServiceOfferingName":
+      "None", "ServiceCategoryName": "None", "AppID": 66, "Attributes": [{"ID": 4902,
+      "Name": "UIUC-TechSvc-CSOC Incident Severity", "Order": 0, "Description": "",
+      "SectionID": 0, "SectionName": null, "FieldType": "dropdown", "DataType": "String",
+      "Choices": [{"ID": 10539, "Name": "To Be Determined", "IsActive": true, "DateCreated":
+      "2023-04-17T20:47:47.447Z", "DateModified": "2023-04-17T20:47:47.447Z", "Order":
+      0}, {"ID": 10541, "Name": "Non-Event", "IsActive": true, "DateCreated": "2023-04-17T20:48:18.213Z",
+      "DateModified": "2023-04-17T20:48:33.57Z", "Order": 1}, {"ID": 10540, "Name":
+      "Low - Minor", "IsActive": true, "DateCreated": "2023-04-17T20:48:05.88Z", "DateModified":
+      "2023-04-17T20:48:24.127Z", "Order": 2}, {"ID": 10203, "Name": "Medium - Moderate",
+      "IsActive": true, "DateCreated": "2023-03-13T19:34:05.207Z", "DateModified":
+      "2023-04-17T20:49:23.907Z", "Order": 3}, {"ID": 10204, "Name": "High - Serious",
+      "IsActive": true, "DateCreated": "2023-03-13T19:34:05.217Z", "DateModified":
+      "2023-04-17T20:49:18.803Z", "Order": 4}, {"ID": 10542, "Name": "Critical - Major",
+      "IsActive": true, "DateCreated": "2023-04-17T20:49:12.407Z", "DateModified":
+      "2023-04-17T20:49:12.407Z", "Order": 5}, {"ID": 15624, "Name": "Mutli-Campus",
+      "IsActive": true, "DateCreated": "2023-12-05T19:40:38.35Z", "DateModified":
+      "2023-12-05T19:40:38.35Z", "Order": 6}], "IsRequired": false, "IsUpdatable":
+      true, "Value": "10539", "ValueText": "To Be Determined", "ChoicesText": "To
+      Be Determined", "AssociatedItemIDs": [0]}, {"ID": 4363, "Name": "UIUC-TechSvc-Security
+      TLP", "Order": 0, "Description": "Traffic Light Protocol sharing classification
+      - See also https://wiki.illinois.edu/wiki/display/SEC/Traffic+Light+Protocol+-TLP",
+      "SectionID": 0, "SectionName": null, "FieldType": "dropdown", "DataType": "String",
+      "Choices": [{"ID": 8175, "Name": "TLP:CLEAR", "IsActive": true, "DateCreated":
+      "2022-06-29T20:23:50.033Z", "DateModified": "2023-09-14T17:33:23.823Z", "Order":
+      0}, {"ID": 8174, "Name": "TLP:GREEN", "IsActive": true, "DateCreated": "2022-06-29T20:23:49.927Z",
+      "DateModified": "2022-06-29T20:23:49.927Z", "Order": 1}, {"ID": 8173, "Name":
+      "TLP:AMBER", "IsActive": true, "DateCreated": "2022-06-29T20:23:49.827Z", "DateModified":
+      "2022-06-29T20:23:49.827Z", "Order": 2}, {"ID": 14037, "Name": "TLP:AMBER+STRICT",
+      "IsActive": true, "DateCreated": "2023-09-14T17:33:09.307Z", "DateModified":
+      "2023-09-14T17:33:09.307Z", "Order": 3}, {"ID": 8172, "Name": "TLP:RED", "IsActive":
+      true, "DateCreated": "2022-06-29T20:23:49.723Z", "DateModified": "2023-09-14T17:33:16.707Z",
+      "Order": 4}], "IsRequired": false, "IsUpdatable": true, "Value": "8172", "ValueText":
+      "TLP:RED", "ChoicesText": "TLP:RED", "AssociatedItemIDs": [0]}], "Attachments":
+      [], "Tasks": [], "Notify": [{"ItemRole": "Responsible Group", "Name": "UIUC-TechServices-Cybersecurity
+      Developers", "Initials": null, "Value": "787", "RefValue": 0, "ProfileImageFileName":
+      null}, {"ItemRole": "Requestor", "Name": "CLEANED CLEANED", "Initials": null,
+      "Value": "CLEANED@illinois.edu", "RefValue": 0, "ProfileImageFileName": null}]}'
     headers:
       Accept:
       - '*/*'
@@ -340,63 +275,43 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7908'
+      - '4301'
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://help.uillinois.edu/SBTDWebApi/api/66/tickets/564073?notifyNewResponsible=False
+    uri: https://help.uillinois.edu/SBTDWebApi/api/66/tickets/1011312?notifyNewResponsible=False
   response:
     body:
-      string: '{"ID":564073,"ParentID":0,"ParentTitle":"","ParentClass":0,"TypeID":312,"TypeName":"Security
+      string: '{"ID":1011312,"ParentID":0,"ParentTitle":"","ParentClass":0,"TypeID":312,"TypeName":"Security
         Support","TypeCategoryID":89,"TypeCategoryName":"UIUC-Privacy and Cybersecurity","Classification":46,"ClassificationName":"Service
-        Request","FormID":693,"FormName":"UIUC-TechServices-Privacy New Request","Title":"NewBoo","Description":"Test
-        request","IsRichHtml":false,"Uri":"api/66/tickets/564073","AccountID":7902,"AccountName":"None/Not
-        Found","SourceID":0,"SourceName":"","StatusID":360,"StatusName":"Resolved","StatusClass":3,"ImpactID":0,"ImpactName":"","UrgencyID":0,"UrgencyName":"","PriorityID":19,"PriorityName":"Low","PriorityOrder":1.0,"SlaID":0,"SlaName":"","IsSlaViolated":false,"IsSlaRespondByViolated":false,"IsSlaResolveByViolated":false,"RespondByDate":"0001-01-01T00:00:00","ResolveByDate":"0001-01-01T00:00:00","SlaBeginDate":"0001-01-01T00:00:00","IsOnHold":false,"PlacedOnHoldDate":"0001-01-01T00:00:00","GoesOffHoldDate":"0001-01-01T00:00:00","CreatedDate":"2022-12-01T17:12:16.05Z","CreatedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","CreatedFullName":"Tech
-        Services Security API","CreatedEmail":"","ModifiedDate":"2023-06-15T19:52:21.613Z","ModifiedUid":"0bfec2fa-e406-ee11-87dd-0050f2e6c034","ModifiedFullName":"Security
-        SOAR API Service Account","RequestorName":"CLEANED CLEANED","RequestorFirstName":"CLEANED","RequestorLastName":"CLEANED","RequestorEmail":"CLEANED@illinois.edu","RequestorPhone":"217-300-5753","RequestorUid":"a3e79204-8fc9-ea11-a81d-000d3a8ea9f7","ActualMinutes":0,"EstimatedMinutes":0,"DaysOld":14,"StartDate":null,"EndDate":null,"ResponsibleUid":"54b3b2ee-90c9-ea11-a81d-000d3a8ea9f7","ResponsibleFullName":"CLEANED
+        Request","FormID":1069,"FormName":"UIUC-TechSvc-CSOC Incidents","Title":"NewBoo","Description":"","IsRichHtml":false,"Uri":"api/66/tickets/1011312","AccountID":7902,"AccountName":"None/Not
+        Found","SourceID":0,"SourceName":"","StatusID":357,"StatusName":"New","StatusClass":1,"ImpactID":0,"ImpactName":"","UrgencyID":0,"UrgencyName":"","PriorityID":19,"PriorityName":"Low","PriorityOrder":1.0,"SlaID":0,"SlaName":"","IsSlaViolated":false,"IsSlaRespondByViolated":false,"IsSlaResolveByViolated":false,"RespondByDate":"0001-01-01T00:00:00","ResolveByDate":"0001-01-01T00:00:00","SlaBeginDate":"0001-01-01T00:00:00","IsOnHold":false,"PlacedOnHoldDate":"0001-01-01T00:00:00","GoesOffHoldDate":"0001-01-01T00:00:00","CreatedDate":"2024-01-31T18:40:32.353Z","CreatedUid":"a68e93bc-e406-ee11-87dd-0050f2e6c034","CreatedFullName":"Security
+        SOAR API Service Account","CreatedEmail":"","ModifiedDate":"2024-01-31T18:51:33.573Z","ModifiedUid":"a68e93bc-e406-ee11-87dd-0050f2e6c034","ModifiedFullName":"Security
+        SOAR API Service Account","RequestorName":"CLEANED CLEANED","RequestorFirstName":"CLEANED","RequestorLastName":"CLEANED","RequestorEmail":"CLEANED@illinois.edu","RequestorPhone":"","RequestorUid":"b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7","ActualMinutes":0,"EstimatedMinutes":0,"DaysOld":0,"StartDate":null,"EndDate":null,"ResponsibleUid":"b4b7b6e8-90c9-ea11-a81d-000d3a8ea9f7","ResponsibleFullName":"CLEANED
         CLEANED","ResponsibleEmail":"CLEANED@illinois.edu","ResponsibleGroupID":787,"ResponsibleGroupName":"UIUC-TechServices-Cybersecurity
-        Developers","RespondedDate":"2022-12-01T17:12:16.05Z","RespondedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","RespondedFullName":"Tech
-        Services Security API","CompletedDate":"2022-12-15T16:42:00.94Z","CompletedUid":"3c3caa7d-c365-ed11-ade6-0050f2e6378b","CompletedFullName":"Tech
-        Services Security API","ReviewerUid":null,"ReviewerFullName":"","ReviewerEmail":"","ReviewingGroupID":0,"ReviewingGroupName":"","TimeBudget":0.0,"ExpensesBudget":0.0,"TimeBudgetUsed":0.0,"ExpensesBudgetUsed":0.0,"IsConvertedToTask":false,"ConvertedToTaskDate":"0001-01-01T00:00:00","ConvertedToTaskUid":null,"ConvertedToTaskFullName":"","TaskProjectID":0,"TaskProjectName":"","TaskPlanID":0,"TaskPlanName":"","TaskID":0,"TaskTitle":"","TaskStartDate":"0001-01-01T00:00:00","TaskEndDate":"0001-01-01T00:00:00","TaskPercentComplete":0,"LocationID":0,"LocationName":"","LocationRoomID":0,"LocationRoomName":"","RefCode":"","ServiceID":0,"ServiceName":"None","ServiceOfferingID":0,"ServiceOfferingName":"None","ServiceCategoryID":0,"ServiceCategoryName":"None","ArticleID":0,"ArticleSubject":"","ArticleStatus":0,"ArticleCategoryPathNames":"","ArticleAppID":0,"ArticleShortcutID":null,"AppID":66,"Attributes":[{"ID":3618,"Name":"UIUC-TechSvc-Privacy
-        Nature of Request","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":5279,"Name":"Customer
-        Service Request/ General Inquiry","IsActive":true,"DateCreated":"2021-10-06T18:23:10.183Z","DateModified":"2021-10-06T18:23:10.183Z","Order":1},{"ID":5280,"Name":"Request
-        a new privacy service, project or capability","IsActive":true,"DateCreated":"2021-10-06T18:23:10.19Z","DateModified":"2021-10-06T18:23:10.19Z","Order":2},{"ID":5281,"Name":"Privacy
-        Consultation","IsActive":true,"DateCreated":"2021-10-06T18:23:10.193Z","DateModified":"2021-10-06T18:23:10.193Z","Order":3},{"ID":5282,"Name":"New
-        purchase / third party product or service review","IsActive":true,"DateCreated":"2021-10-06T18:23:10.2Z","DateModified":"2021-10-06T18:23:10.2Z","Order":4},{"ID":5283,"Name":"Compliance-related
-        question","IsActive":true,"DateCreated":"2021-10-06T18:23:10.207Z","DateModified":"2021-10-06T18:23:10.207Z","Order":5},{"ID":5284,"Name":"Request
-        a privacy impact assessment","IsActive":true,"DateCreated":"2021-10-06T18:23:10.213Z","DateModified":"2021-10-06T18:23:10.213Z","Order":6},{"ID":5285,"Name":"Report
-        a possible data incident","IsActive":true,"DateCreated":"2021-10-06T18:23:10.22Z","DateModified":"2021-10-06T18:23:10.22Z","Order":7},{"ID":5286,"Name":"Other","IsActive":true,"DateCreated":"2021-10-06T18:23:10.227Z","DateModified":"2021-10-06T18:23:10.227Z","Order":8}],"IsRequired":false,"IsUpdatable":false,"Value":"5279","ValueText":"Customer
-        Service Request/ General Inquiry","ChoicesText":"Customer Service Request/
-        General Inquiry","AssociatedItemIDs":[0]},{"ID":3621,"Name":"UIUC-TechSvc-Privacy
-        Data Domains","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"checklist","DataType":"String","Choices":[{"ID":5290,"Name":"General
-        Identification Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.11Z","DateModified":"2021-10-06T18:34:43.11Z","Order":1},{"ID":5291,"Name":"Student
-        and Academic Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.117Z","DateModified":"2021-10-06T18:34:43.117Z","Order":2},{"ID":5292,"Name":"Health
-        and Medical Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.123Z","DateModified":"2021-10-06T18:34:43.123Z","Order":3},{"ID":5293,"Name":"Financial
-        and Consumer Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.13Z","DateModified":"2021-10-06T18:34:43.13Z","Order":4},{"ID":5294,"Name":"Employee
-        and Employment Data","IsActive":true,"DateCreated":"2021-10-06T18:34:43.137Z","DateModified":"2021-10-06T18:34:43.137Z","Order":5},{"ID":5295,"Name":"Legal
-        and Technical Data (Non-Personal Data)","IsActive":true,"DateCreated":"2021-10-06T18:34:43.14Z","DateModified":"2021-10-06T18:34:43.14Z","Order":6}],"IsRequired":false,"IsUpdatable":false,"Value":"5290","ValueText":"General
-        Identification Data","ChoicesText":"General Identification Data","AssociatedItemIDs":[0]},{"ID":3620,"Name":"UIUC-TechSvc-Privacy
-        Identifiable Data","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5287,"Name":"Yes","IsActive":true,"DateCreated":"2021-10-06T18:31:36.607Z","DateModified":"2021-10-06T18:31:36.607Z","Order":0},{"ID":5288,"Name":"No","IsActive":true,"DateCreated":"2021-10-06T18:31:36.613Z","DateModified":"2021-10-06T18:31:36.613Z","Order":1},{"ID":5289,"Name":"I
-        don''t know","IsActive":true,"DateCreated":"2021-10-06T18:31:36.637Z","DateModified":"2021-10-06T18:31:36.637Z","Order":2}],"IsRequired":false,"IsUpdatable":false,"Value":"5288","ValueText":"No","ChoicesText":"No","AssociatedItemIDs":[0]},{"ID":3623,"Name":"UIUC-TechSvc-Privacy
-        Area","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5300,"Name":"Research","IsActive":true,"DateCreated":"2021-10-06T18:38:19.52Z","DateModified":"2021-10-06T18:38:19.52Z","Order":1},{"ID":5301,"Name":"Administrative
-        / Operational","IsActive":true,"DateCreated":"2021-10-06T18:38:19.527Z","DateModified":"2021-10-06T18:38:19.527Z","Order":2},{"ID":5302,"Name":"Health
-        / Student / Employee Wellness","IsActive":true,"DateCreated":"2021-10-06T18:38:19.537Z","DateModified":"2021-10-06T18:38:19.537Z","Order":3},{"ID":5303,"Name":"Student
-        / Academic","IsActive":true,"DateCreated":"2021-10-06T18:38:19.543Z","DateModified":"2021-10-06T18:38:19.543Z","Order":4},{"ID":5304,"Name":"Other","IsActive":true,"DateCreated":"2021-10-06T18:38:19.55Z","DateModified":"2021-10-06T18:38:19.55Z","Order":5}],"IsRequired":false,"IsUpdatable":false,"Value":"5300","ValueText":"Research","ChoicesText":"Research","AssociatedItemIDs":[0]},{"ID":3625,"Name":"UIUC-TechSvc-Privacy
-        Affiliation","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"vradio","DataType":"String","Choices":[{"ID":5305,"Name":"Yes","IsActive":true,"DateCreated":"2021-10-06T18:42:23.347Z","DateModified":"2021-10-06T18:42:23.347Z","Order":0},{"ID":5306,"Name":"No","IsActive":true,"DateCreated":"2021-10-06T18:42:23.357Z","DateModified":"2021-10-06T18:42:23.357Z","Order":1}],"IsRequired":false,"IsUpdatable":false,"Value":"5305","ValueText":"Yes","ChoicesText":"Yes","AssociatedItemIDs":[0]}],"Attachments":[],"Tasks":[],"Notify":[{"ItemRole":"Responsible","Name":"CLEANED
-        CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Responsible
-        Group","Name":"UIUC-TechServices-Cybersecurity Developers","Initials":null,"Value":"787","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Requestor","Name":"CLEANED
-        CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null}],"WorkflowID":0,"WorkflowConfigurationID":0,"WorkflowName":""}'
+        Developers","RespondedDate":"0001-01-01T00:00:00","RespondedUid":null,"RespondedFullName":"","CompletedDate":"0001-01-01T00:00:00","CompletedUid":null,"CompletedFullName":"","ReviewerUid":null,"ReviewerFullName":"","ReviewerEmail":"","ReviewingGroupID":0,"ReviewingGroupName":"","TimeBudget":0.0,"ExpensesBudget":0.0,"TimeBudgetUsed":0.0,"ExpensesBudgetUsed":0.0,"IsConvertedToTask":false,"ConvertedToTaskDate":"0001-01-01T00:00:00","ConvertedToTaskUid":null,"ConvertedToTaskFullName":"","TaskProjectID":0,"TaskProjectName":"","TaskPlanID":0,"TaskPlanName":"","TaskID":0,"TaskTitle":"","TaskStartDate":"0001-01-01T00:00:00","TaskEndDate":"0001-01-01T00:00:00","TaskPercentComplete":0,"LocationID":0,"LocationName":"","LocationRoomID":0,"LocationRoomName":"","RefCode":"","ServiceID":0,"ServiceName":"None","ServiceOfferingID":0,"ServiceOfferingName":"None","ServiceCategoryID":0,"ServiceCategoryName":"None","ArticleID":0,"ArticleSubject":"","ArticleStatus":0,"ArticleCategoryPathNames":"","ArticleAppID":0,"ArticleShortcutID":null,"AppID":66,"Attributes":[{"ID":4902,"Name":"UIUC-TechSvc-CSOC
+        Incident Severity","Order":0,"Description":"","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":10539,"Name":"To
+        Be Determined","IsActive":true,"DateCreated":"2023-04-17T20:47:47.447Z","DateModified":"2023-04-17T20:47:47.447Z","Order":0},{"ID":10541,"Name":"Non-Event","IsActive":true,"DateCreated":"2023-04-17T20:48:18.213Z","DateModified":"2023-04-17T20:48:33.57Z","Order":1},{"ID":10540,"Name":"Low
+        - Minor","IsActive":true,"DateCreated":"2023-04-17T20:48:05.88Z","DateModified":"2023-04-17T20:48:24.127Z","Order":2},{"ID":10203,"Name":"Medium
+        - Moderate","IsActive":true,"DateCreated":"2023-03-13T19:34:05.207Z","DateModified":"2023-04-17T20:49:23.907Z","Order":3},{"ID":10204,"Name":"High
+        - Serious","IsActive":true,"DateCreated":"2023-03-13T19:34:05.217Z","DateModified":"2023-04-17T20:49:18.803Z","Order":4},{"ID":10542,"Name":"Critical
+        - Major","IsActive":true,"DateCreated":"2023-04-17T20:49:12.407Z","DateModified":"2023-04-17T20:49:12.407Z","Order":5},{"ID":15624,"Name":"Mutli-Campus","IsActive":true,"DateCreated":"2023-12-05T19:40:38.35Z","DateModified":"2023-12-05T19:40:38.35Z","Order":6}],"IsRequired":false,"IsUpdatable":true,"Value":"10539","ValueText":"To
+        Be Determined","ChoicesText":"To Be Determined","AssociatedItemIDs":[0]},{"ID":4363,"Name":"UIUC-TechSvc-Security
+        TLP","Order":0,"Description":"Traffic Light Protocol sharing classification
+        - See also https://wiki.illinois.edu/wiki/display/SEC/Traffic+Light+Protocol+-TLP","SectionID":0,"SectionName":null,"FieldType":"dropdown","DataType":"String","Choices":[{"ID":8175,"Name":"TLP:CLEAR","IsActive":true,"DateCreated":"2022-06-29T20:23:50.033Z","DateModified":"2023-09-14T17:33:23.823Z","Order":0},{"ID":8174,"Name":"TLP:GREEN","IsActive":true,"DateCreated":"2022-06-29T20:23:49.927Z","DateModified":"2022-06-29T20:23:49.927Z","Order":1},{"ID":8173,"Name":"TLP:AMBER","IsActive":true,"DateCreated":"2022-06-29T20:23:49.827Z","DateModified":"2022-06-29T20:23:49.827Z","Order":2},{"ID":14037,"Name":"TLP:AMBER+STRICT","IsActive":true,"DateCreated":"2023-09-14T17:33:09.307Z","DateModified":"2023-09-14T17:33:09.307Z","Order":3},{"ID":8172,"Name":"TLP:RED","IsActive":true,"DateCreated":"2022-06-29T20:23:49.723Z","DateModified":"2023-09-14T17:33:16.707Z","Order":4}],"IsRequired":false,"IsUpdatable":true,"Value":"8172","ValueText":"TLP:RED","ChoicesText":"TLP:RED","AssociatedItemIDs":[0]}],"Attachments":[],"Tasks":[],"Notify":[{"ItemRole":"Responsible,
+        Requestor","Name":"CLEANED CLEANED","Initials":null,"Value":"CLEANED@illinois.edu","RefValue":0,"ProfileImageFileName":null},{"ItemRole":"Responsible
+        Group","Name":"UIUC-TechServices-Cybersecurity Developers","Initials":null,"Value":"787","RefValue":0,"ProfileImageFileName":null}],"WorkflowID":0,"WorkflowConfigurationID":0,"WorkflowName":""}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '8724'
+      - '5664'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 15 Jun 2023 19:52:21 GMT
+      - Wed, 31 Jan 2024 18:51:33 GMT
       Expires:
       - '-1'
       Pragma:
@@ -410,7 +325,7 @@ interactions:
       X-RateLimit-Remaining:
       - '58'
       X-RateLimit-Reset:
-      - Thu, 15 Jun 2023 19:53:19 GMT
+      - Wed, 31 Jan 2024 18:52:30 GMT
       X-TDX-Entity:
       - '2'
       X-TDX-EntityName:
@@ -418,9 +333,9 @@ interactions:
       X-TDX-Partition:
       - '26'
       X-TDX-TraceID:
-      - b02cda83-7e07-413c-9c58-1c93eefd3d19
+      - '2565068148529634202'
       X-TDX-UID:
-      - 0bfec2fa-e406-ee11-87dd-0050f2e6c034
+      - a68e93bc-e406-ee11-87dd-0050f2e6c034
       X-UA-Compatible:
       - IE=edge
     status:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -8,7 +8,11 @@ from app.app import OrgNameAndEndpointSet, OrgNameAndEndpointNotSet
 from conftest import VCR_RECORD, CASSETTE_NETID
 
 APP_ID = "tacosalad"
-TICKET_ID = 564073  # Must match cassette
+#  TICKET_ID must match ticket ID found in
+#  cassettes/test_create_ticket.yaml
+
+#  PROTIP: After re-recording test_create_ticket.yaml, update this Ticket ID.
+TICKET_ID = 564073
 
 
 def test_connectivity(cassette, connector: TdxConnector):

--- a/tests/test_reassign.py
+++ b/tests/test_reassign.py
@@ -5,7 +5,13 @@ from app.app import TdxConnector
 from conftest import CASSETTE_NETID
 
 APP_ID = "tacosalad"
-TICKET_ID = 564073  # Must match cassette
+#  TICKET_ID must match ticket ID found in
+#  cassettes/test_reassign_user.yaml
+#  cassettes/test_reassign_group.yaml
+
+#  PROTIP: After the TDX Sandbox environment gets reset, you'll have to
+#  go digging for a new ticket ID in order to re-record these cassettes.
+TICKET_ID = 1011312
 
 
 def test_reassign_group(cassette, connector: TdxConnector):


### PR DESCRIPTION
This PR addresses ticket drift due to the TDX Sandbox reset. Ticket IDs we were using for cassettes were nonexistent.

Closes #94 