### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         make build-test
     - name: Store build as an artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: deployed tar file
         path: app.tar


### PR DESCRIPTION
`Deploy.yml` is failing because actions/upload-artifact@v3 is deprecated as of November, 2024:

https://github.com/actions/upload-artifact

