### PR TITLE
Update end-of-life dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ twice annual releases could include breaking API changes.
 End-of-Life was decided upon based on these dependencies:
 
   - Python 3.13 (Oct 2029)
-  - phantom-toolbox Python library (Sep 2027)
-  - Splunk SOAR (Estimated July 2027)
-  - TeamDynamix (Estimated May 2026)
+  - phantom-toolbox Python library (April 2028)
+  - Splunk SOAR (April 2028)
+  - TeamDynamix (Estimated December 2026)
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This product is supported by Cybersecurity teams at the
 University of Illinois Urbana-Champaign on a best-effort basis.
 
 As of the last update to this README, the expected End-of-Life and 
-End-of-Support dates of this product are May 2026.
+End-of-Support dates of this product are December 2026.
 
 We estimate Splunk SOAR end-of-support by assuming it roughly follows Splunk,
 and that the SOAR cloud has the latest version installed.


### PR DESCRIPTION
+ Splunk SOAR 8.5.0 should be supported 24 months after the April 2026 release.
+ The key factor in phantom-toolbox is Splunk SOAR (see  https://github.com/techservicesillinois/phantom-toolbox/pull/47)
+ We generally assume six months of compatibility with TeamDynamix from the code update. In this case, December of 2026.

Closes #167